### PR TITLE
fix(Codestyle): compare SQL changes against main

### DIFF
--- a/apps/codestyle/codestyle-sql.py
+++ b/apps/codestyle/codestyle-sql.py
@@ -42,11 +42,11 @@ def collect_files_from_directories(directories: list) -> list:
                     all_files.append(os.path.join(root, file))
     return all_files
 
-# Used to find changed or added files compared to master.
+# Used to find changed or added files compared to main.
 def get_changed_files() -> list:
-    subprocess.run(["git", "fetch", "origin", "master"], check=True)
+    subprocess.run(["git", "fetch", "origin", "main"], check=True)
     result = subprocess.run(
-        ["git", "diff", "--name-status", "origin/master"],
+        ["git", "diff", "--name-status", "origin/main"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
## Problem and resulting behavior

The SQL linter fetches `origin/master`, which does not exist in this repository. It aborts before
reporting its final results and checking modified base/archive files. Fetch and compare against
`origin/main`, the repository's default branch, and update the adjacent comment.

## Validation and remaining limits

The original entry point fails with `couldn't find remote ref master`. With this fix it reaches all
eight check results, including the base/archive directory check. The run still exits 1 for 506 SQL
diagnostics already present on main; a before/after comparison confirms those diagnostics are identical.
This change fixes the branch lookup and does not claim a clean SQL tree. Full C++ lint and git diff
--check pass. GPT Sol found no blocking findings in commit 1741a6716.

This is a Python tooling-only change. No in-game testing applies.

## Data/source dependencies

Only apps/codestyle/codestyle-sql.py changes: two branch references and their comment. Applied SQL is
unchanged. No credentials, profiles, game archives or derived game data are included. The source-only guard passes.
