### PR TITLE
fix(Core): Prevent startup metadata crashes

### DIFF
--- a/modules/mod-ascension-compat/src/AscensionVenomancerAbilities.cpp
+++ b/modules/mod-ascension-compat/src/AscensionVenomancerAbilities.cpp
@@ -402,12 +402,16 @@ class spell_ascension_venomancer_ability : public SpellScript
     }
     void Register() override
     {
-        if (GetSpellInfo()->HasEffect(SPELL_EFFECT_DUMMY))
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(m_scriptSpellId);
+        if (!spellInfo)
+            return;
+
+        if (spellInfo->HasEffect(SPELL_EFFECT_DUMMY))
         {
             OnEffectHitTarget += SpellEffectFn(spell_ascension_venomancer_ability::Effect,EFFECT_ALL,SPELL_EFFECT_DUMMY);
             OnEffectHit += SpellEffectFn(spell_ascension_venomancer_ability::Effect,EFFECT_ALL,SPELL_EFFECT_DUMMY);
         }
-        if (GetSpellInfo()->HasEffect(SPELL_EFFECT_SUMMON))
+        if (spellInfo->HasEffect(SPELL_EFFECT_SUMMON))
         {
             OnEffectHit += SpellEffectFn(spell_ascension_venomancer_ability::SkipSummon,EFFECT_ALL,SPELL_EFFECT_SUMMON);
             OnEffectHitTarget += SpellEffectFn(spell_ascension_venomancer_ability::SkipSummon,EFFECT_ALL,SPELL_EFFECT_SUMMON);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -1731,9 +1731,13 @@ void ObjectMgr::LoadCreatureModelInfo()
     {
         Field* fields = result->Fetch();
 
-        uint32 displayId = fields[0].Get<uint32>();
-        CreatureDisplayInfoEntry const* creatureDisplay = sCreatureDisplayInfoStore.LookupEntry(displayId);
         uint32 modelId = fields[0].Get<uint32>();
+        CreatureDisplayInfoEntry const* creatureDisplay = sCreatureDisplayInfoStore.LookupEntry(modelId);
+        if (!creatureDisplay)
+        {
+            LOG_ERROR("sql.sql", "Table `creature_model_info` references missing display id ({}), skipping.", modelId);
+            continue;
+        }
 
         CreatureModelInfo& modelInfo = _creatureModelStore[modelId];
 
@@ -1744,9 +1748,6 @@ void ObjectMgr::LoadCreatureModelInfo()
         modelInfo.is_trigger           = false;
 
         // Checks
-
-        if (!sCreatureDisplayInfoStore.LookupEntry(modelId))
-            LOG_ERROR("sql.sql", "Table `creature_model_info` has model for not existed display id ({}).", modelId);
 
         if (modelInfo.gender > GENDER_NONE)
         {


### PR DESCRIPTION
## Problem and resulting behavior

Worldserver crashes during creature model loading when `creature_model_info` references a display missing from the server DBCs. Check the display before storing model metadata or dereferencing it, log the missing ID, and skip that row.

Venomancer script registration also crashes during startup because `GetSpellInfo()` accesses a live spell cast that doesn't exist yet. Look up the initialized script spell ID through `SpellMgr` and retain the existing dummy and summon effect hooks.

## Validation and remaining limits

Validated commit `e4661b815cc84810fe298a0a82c472f01a156299` on Windows:

- VS2022 x64 RelWithDebInfo build of authserver and worldserver passed.
- Scoped C++ style checks and Git whitespace checks passed.
- Native import into empty MySQL 8.4.9 completed, followed by full worldserver startup and a clean shutdown.
- With the older DBCs, startup skipped exactly 16 missing displays and reached readiness. With matching CoA data, startup produced no missing-model warnings.
- Startup from the rebuilt repack's extracted archive passed.

In-game rendering and gameplay remain untested. Existing nonfatal content warnings, including class proc HitMask warnings, remain.

- [x] AI assistance: Codex (GPT-6) produced the source changes and this description.

## Data/source dependencies

Matching CoA server DBCs and client assets are still required to use the affected models. The guard prevents the startup crash but doesn't supply missing assets. Matching server data is included in the separately rebuilt repack.

Applied SQL is unchanged. This PR contains only the two C++ files above; no credentials, profiles, binaries, DBCs or game archives are included.
