### PR TITLE
feat(Codestyle): Add scoped offline checks

### DIFF
--- a/.agents/docs/README.md
+++ b/.agents/docs/README.md
@@ -1,7 +1,6 @@
 # .agents/docs
 
-Task-scoped agent guidance, routed from AGENTS.md's "Mandatory reading per task". Keep every doc
-compact and agent-agnostic.
+Task references routed from AGENTS.md. Read only relevant sections and keep guidance compact.
 
 ## Taxonomy
 
@@ -14,7 +13,9 @@ compact and agent-agnostic.
 
 - The most specific applicable doc wins.
 - Generic language lesson → the language doc (e.g. generic C++ → `cpp-guidelines.md`).
-- Subsystem-specific lesson → `systems/<subsystem>.md`; create it if missing.
+- Subsystem-specific guidance → the relevant document in `systems/`.
 - Extend an existing doc before creating a new one.
-- A new doc REQUIRES adding its routing bullet to AGENTS.md's "Mandatory reading per task" in the
-  same change.
+- Create a document only when requested or when substantial reusable guidance needs a home.
+- Add routing only when needed for discovery; do not make every new lesson mandatory reading.
+- Keep task histories, hashes, process IDs, failed phases, and acceptance receipts in existing task/release records.
+  Ordinary changes need no new document or report. Do not automatically suggest skills or lesson capture.

--- a/.agents/docs/code-review.md
+++ b/.agents/docs/code-review.md
@@ -1,19 +1,16 @@
 # Code review
 
-Reviewing a changeset or PR, your own before submission or a contributor's. The task-scoped docs
-(`cpp-guidelines.md`, `sql-guidelines.md`, `cpp-scripts.md`) apply as a checklist to every changed
-line, not as background reading.
+Review the requested changeset or PR and affected dependencies. Use relevant language/subsystem guidance.
+Routine self-checks do not require a formal report, a clean working tree, or a committed review round.
 
 - A posted review carries findings only: no summary, no praise. Nothing to report means one line
   saying so.
-- Label `To Be Merged` only on a merge-ready PR, approved or not; remove `Ready to be Reviewed` in
-  the same step.
 - A finding names what is wrong, why it matters and the fix, on the offending line. Findings are
   bugs, crashes, lifetime and memory errors, data-integrity problems, injection, and violations of
   a rule written down in AGENTS.md or `.agents/docs/`; taste no rule covers is not a finding.
-- Review codestyle on every changed line, even when style is not the change's subject. Run both
-  linters and report violations as findings: `python apps/codestyle/codestyle-cpp.py` and
-  `python apps/codestyle/codestyle-sql.py`.
+- Run the affected language's linter on changed files with `--files <path> ...`:
+  `python apps/codestyle/codestyle-cpp.py` or `python apps/codestyle/codestyle-sql.py`.
+  Do not run unrelated linters or full-tree scans for a small diff. Documentation-only changes need no code lint.
 - Title and description follow the [commit message guidelines](https://www.azerothcore.org/wiki/commit-message-guidelines).
 - Prefer data over code: when a C++ or script change is also achievable through world DB data
   (SmartAI, conditions, templates), flag the DB-only alternative (see `cpp-scripts.md`).
@@ -24,15 +21,9 @@ line, not as background reading.
   states it can leave behind (null, empty, fall-through) into every consumer of them — including
   unchanged lines the new flow now reaches — and verify what runs when an acquire/attack/GetX
   call leaves a null result, not just what enables it.
-- Check the change is still needed against current `master`: the surrounding code may have moved,
+- Check the change against the actual target branch (`main` in this fork): the surrounding code may have moved,
   or another change may have landed the same fix.
-- On an existing PR, walk every discussion item one by one, bot reviews included: what was raised,
-  whether it was answered, and whether it still applies to the current head. Never skip one
-  because it looks resolved, old, or minor; this walk overrides any read-comments-lightly default
-  of the reviewing skill. `gh pr view` misses review bodies and inline threads; pull all three:
-
-  ```
-  gh api repos/azerothcore/azerothcore-wotlk/issues/<N>/comments --paginate  # conversation comments
-  gh api repos/azerothcore/azerothcore-wotlk/pulls/<N>/reviews --paginate    # review verdicts + bodies
-  gh api repos/azerothcore/azerothcore-wotlk/pulls/<N>/comments --paginate   # inline comments
-  ```
+- On an existing PR, read unresolved discussions and resolved items affected by the current diff, including relevant
+  bot findings. Fetch review bodies/inline threads when needed; use the actual PR repository, not a fixed upstream URL.
+  A complete historical discussion audit is needed only when requested or relevant to an unresolved issue.
+- Do not post reviews, comments, or change PR labels unless the user authorized that action.

--- a/.agents/docs/cpp-guidelines.md
+++ b/.agents/docs/cpp-guidelines.md
@@ -1,6 +1,7 @@
 # C++ guidelines
 
-Run the linter before claiming a change is done: `python apps/codestyle/codestyle-cpp.py`
+For C++ changes, lint the affected files: `python apps/codestyle/codestyle-cpp.py --files <path> ...`.
+The no-argument command retains the full `src/` scan for broad checks; routine edits do not require it.
 
 ## Code style
 

--- a/.agents/docs/self-review-rules.md
+++ b/.agents/docs/self-review-rules.md
@@ -1,34 +1,21 @@
 # Self-review rules
 
-Project-specific rules for
-[/self-review](https://github.com/eai-org/agent-toolkit/blob/main/skills/self-review/SKILL.md).
-Add here rules about reviewing AzerothCore PRs before they are submitted. Generic improvements
-to the review process itself belong to the skill, not here. The [code-review.md](code-review.md)
-rules apply on top.
+Use these rules when preparing an actual PR, together with [code-review.md](code-review.md).
+Routine local edits need a focused diff review, not a separate review workflow or report.
 
-## Pinned review
+## Review scope
 
-The report is pasted into the PR, so the review must be pinned to a commit: uncommitted changes
-(except local-only tweaks) block the run, and fixes from a round are committed before the next one.
+- Review the final requested changes and their affected consumers. A working-tree diff is a valid review target;
+  uncommitted changes do not block review. Do not commit merely to satisfy a review procedure.
+- Identify the reviewed commit/diff when publishing a PR review. Re-review only new changes or unresolved findings.
+- For shared core C++ and headers, inspect affected callers and lifecycle behavior. For contained content/module
+  changes, concentrate on the affected mechanic. For SQL, check selection scope and unintended data changes.
 
-## Regression risk
+## Validation
 
-Automated test coverage is near zero, so this review is the main safety net against regressions.
-Every change gets the full review; go deeper the farther it can reach:
-
-- Shared core C++ (`src/server/game/`, `src/common/`, widely-included headers): one fix can
-  break unrelated features — examine how the changed code is used elsewhere, not just the
-  change itself.
-- Content scripts (`src/server/scripts/`) and modules: impact is mostly contained — worst case
-  is usually the one boss, spell, or module touched.
-- SQL: beyond the usual review, watch for the classic side effect — a DELETE/UPDATE whose
-  WHERE clause catches rows it shouldn't.
-
-## In-game testing
-
-PRs are expected to be tested in-game, which the reviewer cannot do. Never guess what the
-author already tested — ask them, and record the answer in the report. Then tell them what
-else to test — especially side effects they might not expect: a fix for X that also reaches Y
-means testing Y too. When the author's tested scenario matches the change's main path, probe
-the branches it doesn't take — regressions hide there. Invite them to ask questions if
-anything is unclear.
+- Use relevant existing tests and the affected language's scoped lint. Add tests when a meaningful behavior change
+  needs coverage; do not create tests for documentation or trivial edits.
+- Stop after the relevant checks pass unless the code changes or a specific concern remains.
+- Report known in-game results and their source. If gameplay is untested, say so; do not invent acceptance or
+  require a user test before completing a source-only task. Ask for missing results only when needed for the task.
+- Client launches still require the user's permission. Review does not authorize a build or deployment.

--- a/.agents/docs/sql-guidelines.md
+++ b/.agents/docs/sql-guidelines.md
@@ -6,7 +6,9 @@
 2. `./create_sql.sh` generates an empty `rev_<timestamp>.sql` to write into.
 3. Conventions (linted): every `INSERT` preceded by a matching `DELETE` (idempotency); no double semicolons; no multiple blank lines; InnoDB engine.
 
-Run the linter before claiming a change is done: `python apps/codestyle/codestyle-sql.py` (compares to origin/master).
+For SQL changes, lint the affected files: `python apps/codestyle/codestyle-sql.py --files <path> ...`.
+Use `--base <local-ref>` when selecting changes against a branch. The linter does not fetch from the network.
+The no-argument command retains broad SQL checks and resolves a locally available default comparison branch.
 
 ## Data conventions
 

--- a/.agents/docs/systems/ascension-local-deployment.md
+++ b/.agents/docs/systems/ascension-local-deployment.md
@@ -1,51 +1,40 @@
 # Guarded local Ascension deployment
 
-Reusable lessons from the 2026-09-06 deployment. Follow current root authorization and build rules;
-this guide does not itself authorize builds, restarts or wider mutations. Only the copied local client
-and isolated local services are in scope. Historical task installers are fixed plans, not generic tools.
+Use the relevant sections for an authorized deployment or a change to deployment tooling.
+Routine source/documentation edits do not need this workflow. Follow current root authorization and build rules.
+Historical task installers are fixed plans, not generic tools. Both Launcher copies contain local changes.
 
 ## Keep the change set coherent
 
-1. Identify the generator/policy and exact before/after scope for SQL, binary and client data. Preserve
-   dirty worktrees. Record candidate hashes and package contents; never silently accept unknown drift.
+1. Identify the affected source, SQL, binary, and client data. Preserve unrelated work and use existing tools.
+   Match the candidate to the requested change; do not create source snapshots or manifests by default.
 2. A new module `.cpp` required reconfiguring the existing CMake build to refresh its source glob.
    Do not infer inclusion from a successful incremental build. Configure/build only when authorized;
    follow `build.md` and the current tested parallelism limits rather than unbounded `/MP`.
-3. Build client packages from canonical candidates. Resolve the effective MPQ carrier for each member;
-   patch-B is not a universal DBC carrier. Re-extract and hash-check the new member and prove that
-   unrelated content is unchanged. A verified packaging manifest is not proof of live deployment.
-4. Gracefully close the exact copied-client process so SavedVariables flush, stop the local world
-   safely, then take and verify the relevant offline backup. Preserve original Launcher and caches.
-   State backup scope accurately: all character tables plus selected world tables is not a whole-world dump.
-5. Verify current state against the backup before installing anything. Install the coherent candidate
-   set while offline, then verify files, pending migration list/hashes and protected data again.
-6. Apply SQL through the normal updater at server startup; do not manually apply it as well. Verify the
-   exact new rows, unchanged unrelated rows, updater name/hash, readiness and new unique errors before login.
+3. Build the final client package from canonical candidates. Resolve the effective MPQ carrier for changed members;
+   patch-B is not a universal DBC carrier. Check the final changed members and preserve unrelated content through
+   the existing packaging tool. Full archive comparisons are for packaging changes or a concrete corruption concern.
+4. Before replacing live files, stop the exact affected process gracefully and preserve one recoverable copy of
+   the affected state. Reuse the tool's backup or an equivalent existing copy; do not add a second manual backup.
+   Back up databases consistently when the deployment changes them, not for unrelated UI/source edits.
+5. Install the coherent candidate with existing guards, then check installed identity and affected behavior.
+   Do not compare unrelated files, whole databases, or every historical phase as a routine deployment requirement.
+6. Apply SQL through the normal updater at server startup; do not manually apply it as well. Check affected rows,
+   migration identity, readiness, and new startup errors. Preserve unrelated/player data.
    `updates.state = PENDING` can describe an already applied pending-directory migration; inspect its
    recorded name/hash and the actual pending-file comparison, not that state string alone.
-7. Launch with the guarded client helper and verify fresh process/path, archive hashes, stock auth,
-   addon permission and existing compatibility checks. Do not reuse an old success JSON as fresh proof.
-   A running client and correct archives still do not prove a rendered tooltip or real combat result.
+7. Launch the client for testing only with the user's permission, using the existing helper. State any untested
+   gameplay limits; an installed package or running process alone does not prove combat or rendered UI behavior.
 
 ## Treat verification reads as data with failure modes
 
-- A MySQL CLI exit code of zero and empty stdout did occur for nonempty/metadata reads. Do not interpret
-  that as an empty table or a verification PASS. Frame read-only output with explicit begin/end markers
-  and reject missing/truncated framing; metadata queries such as SHOW COLUMNS must also return columns.
-- Bound retries to the identical SELECT/SHOW and record retries. Never retry ambiguous writes by analogy.
-  Do not strip malformed rows or weaken fingerprints to make the comparison pass. Keep credentials out
-  of tool output, normalized reports and manifests.
-- Preserve exact pre/post row evidence for operational deltas. A live world legitimately changes
-  respawn timers/worldstates, but this does not justify ignoring entire tables. Validate particular
-  rows, keys, map/instance and source of change; unexpected changes stop verification.
-- **User correction, 2026-09-06:** respawn timers and Wintergrasp state are expected to advance after
-  restart even with no players online. Do not repeatedly compare them to an ever-stale exact snapshot,
-  misdiagnose this as an installation failure, or restart solely to force equality. Keep personal-data
-  and intended SQL checks strict; review a bounded operational snapshot separately and state its time.
-  Verification scope should be proportional to the change, not an unrelated full-world immobility test.
-- Report strict whole-database equality separately from a reviewed operational-delta result. The
-  Barbarian deployment's 32 expired outdoor Northrend respawns are an example, not a blanket future
-  allowance. Personal characters, inventory, spells, skills and collections remain protected.
+- Empty/truncated MySQL output is not proof that a query returned no rows. Verify meaningful output;
+  metadata queries such as SHOW COLUMNS must return columns. Reuse the existing query tooling.
+- Bound retries of read-only queries. Never blindly retry ambiguous writes or hide malformed output.
+  Keep credentials out of tool output and reports.
+- Check the rows and relationships affected by the migration. Respawn timers and Wintergrasp state normally
+  advance after restart, even without players. Do not demand whole-database equality or restart to force it.
+  Investigate an unexpected change relevant to the task; preserve characters, inventory, spells, and collections.
 - Compare new unique startup errors as well as readiness. Existing noisy errors should neither hide a
   new failure nor be called fixed by this deployment. A failed guard must not be relabelled PASS.
 
@@ -70,11 +59,13 @@ and isolated local services are in scope. Historical task installers are fixed p
 
 ## PowerShell and installer regressions
 
+These checks apply when changing the corresponding installer behavior, not when merely using a working installer.
+
 - Python launched from pwsh/VS can pass a PowerShell 7 `PSModulePath` into Windows PowerShell 5.1.
   This caused `Get-FileHash` to be unavailable in an otherwise valid isolated installer test.
   Check the child interpreter/module environment before blaming the installer or removing hash checks.
 - For built-in-only fixtures, set the **child process** module path to that interpreter's `Modules`
-  directory. Test both System32 and SysWOW64 Windows PowerShell 5.1 when the actual launcher is x86.
+  directory. Test the affected production interpreter; add x86/x64 coverage when architecture behavior changes.
   Do not globally change the user's module path or assume the fixture setup replaces production checks.
 - Assert the expected failure message, not merely a nonzero exit status: a missing cmdlet must not
   masquerade as a successful wrong-hash or running-client rejection. Verify target bytes and backups.
@@ -84,18 +75,17 @@ and isolated local services are in scope. Historical task installers are fixed p
 
 ## Handoff and rollback
 
-Keep dated deployment records with exact hashes, applied SQL, backup scope/path, phase results,
-known deltas and untested gameplay. Keep reusable rules here instead of duplicating old hashes.
+For a deployment, record the result, installed version, applied SQL, rollback location, and material limits once
+in the existing release/task record. Reuse the tool output; do not generate a separate receipt per check or phase.
+Routine source work needs only the conversation summary. Keep reusable rules here and release identity in its record.
 An old executable alone is not necessarily a valid rollback after a SQL migration/client data change.
 Review a coherent reverse plan and preserve player progress acquired since the backup; do not restore
 the entire character database merely to undo a spell coefficient or to make a comparison pass.
 
 Examples to inspect, not blindly rerun for a new task:
 
-- `C:/Ascension/tools/Check-BarbarianDeployment.py` — framed read-only queries and bounded retries.
-- `C:/Ascension/tools/Check-BarbarianDamageDeployment.py` — backup/preinstall/offline-installed/live phases.
 - `C:/Ascension/Sync-LocalClientSpellPatch.ps1` — fixed-candidate archive synchronization with backup.
-- `C:/Ascension/tools/Test-BarbarianDamageFix.py` — isolated x86/x64 success and failure scenarios.
+- `C:/Ascension/Sync-LocalClientUiPatch.ps1` — client UI synchronization with backup and identity checks.
 - `C:/Ascension/runtime/validation/barbarian-damage-20260906/implemented.md` — evidence and limitations.
 
 ## Native lifecycle checks learned from Manastorm
@@ -103,9 +93,9 @@ Examples to inspect, not blindly rerun for a new task:
 - `Player::LoadFromDB` can update achievement criteria before `SetMap`. Global player hooks must
   handle a missing map with `FindMap`; `GetMap` asserts. A mapless player must retain ordinary
   achievement behavior. Scene entry and ownership must also reject mapless transfer states.
-- Readiness alone does not exercise character loading. For a lifecycle correction, reproduce the
-  failing callback with actual source and a mapless player, preserve the old-code failure, and test
-  ordinary/private-map behavior. Keep real login and gameplay acceptance distinct from this harness.
+- Readiness alone does not exercise character loading. For a lifecycle correction, use a focused regression
+  for the failing callback and affected map states. A new standalone harness or archived failure is not required.
+  Keep real login and gameplay acceptance distinct from source checks.
 - Native ChatCommandBuilder stores a reference to its child command vector. Keep child tables alive
   (for example, static storage); an inline temporary compiles but can crash command initialization.
 
@@ -121,6 +111,5 @@ Examples to inspect, not blindly rerun for a new task:
   group 1038 includes a stat-percent subgroup, despite also listing Sanctuary. A damage-taken aura
   requires a group that actually selects its aura type. Verify largest-only stacking and preservation
   of independent absorb/stagger effects using the real native group methods.
-- When a later correction adds a previously unmodified table, preserve the original full backup and
-  add one verified table supplement. Validate the amended exact plan against both baselines; do not
-  rewrite the original backup plan or rerun a full backup merely to satisfy an old table-count check.
+- If a deployment's scope grows to another table, preserve its relevant pre-change state once. Reuse existing
+  recoverable backups; do not rerun a full backup merely to satisfy an old table-count check.

--- a/.agents/docs/systems/ascension-spell-parity.md
+++ b/.agents/docs/systems/ascension-spell-parity.md
@@ -1,7 +1,8 @@
 # Ascension spell calculations and tooltip parity
 
-Reusable lessons verified in this local fork through 2026-09-07. Reinspect the current code and effective
-data before applying them to another spell. The official backend is not available as a parity oracle.
+Read only the calculation or subsystem sections relevant to the task. These examples are technical references,
+not a full verification checklist or a statement of current deployment. Reinspect relevant code/data before reuse.
+The official backend is not available as a parity oracle.
 Acquisition, displayed values, server mechanics and observed combat are separate verification layers.
 
 ## Establish the calculation contract first
@@ -73,19 +74,19 @@ the target's armor or reconstruct the two events.
 
 ## Verification that can be reused
 
-- Extract current native calculation functions/blocks into bounded harnesses where practical. Verify
-  stub constants, enum masks, rank lookup, signed fields and encodings against source; wrong test
-  doubles can invent a failure. Do not rewrite the expected formula into both sides of the test.
-- Cover all relevant ranks/slots, distinct AP and RAP, zero/nonzero SP, modifiers, helper counts,
-  periodic timing, repeated callback calls, wrong spell/class/NPC, existing SQL bonus and overflow.
-  Include a negative control that recreates the original defect and asserts the intended failure.
-- Test client description-only edits by restoring changed offsets/header fields and comparing all
-  original bytes. Preserve old shared strings and numeric fields. Re-extract the packaged member and
-  verify its hash; edit generator-owned candidates through their generator, not live-only files.
+- Start with existing functional tests. Add a focused regression when the changed behavior needs coverage;
+  create a native extraction harness only when existing tests cannot exercise a material risk.
+  Validate any necessary test doubles against source; do not copy the expected formula into both sides of a test.
+- Select cases relevant to the change: affected ranks, distinct AP/RAP/SP, ownership, timing, duplicate callbacks,
+  modifiers, or overflow as applicable. A small correction does not require the entire matrix or other classes.
+- Edit generator-owned candidates through their generator. For description changes, check the changed strings
+  and preservation of numeric fields. Verify the final changed MPQ member when packaging; do not create a new
+  snapshot, byte-restoration harness, or phase manifest merely for a text edit.
 - Report coverage precisely: an extracted formula/armor block is not a full hit/crit/proc test;
   a successful build or open window is not combat validation. Keep unresolved contracts explicit.
-- Keep pinned before-evidence immutable. A diagnostic asserting missing coefficients should reject
-  the installed fix, not regenerate the old conclusion from changed state.
+- Historical diagnostics and input-hash assertions describe their captured release. Keep them out of ordinary
+  functional regression selection; preserve existing evidence and numerical assertions, and report stale tooling
+  honestly. Routine tests need no new before/after trees, receipts, or permanent output folders.
 
 ## Stationary summons and formation bundles
 
@@ -259,8 +260,8 @@ Preserve the pending Pyromancer, Cultist and Sun Cleric packages and current nat
   preserve base forms until a trustworthy augmented model is identified.
 - Regeneration must pay all current-stack costs before healing. Barbed Stinger's global HIT phase
   may have no target and must not consume the action before the target HIT embeds or rips it.
-- Native /Zs and fixture checks are separate from server linking, startup registration and live
-  gameplay. Retain failed phases, pin final inputs, and do not present a lint refresh as a regression run.
+- Native /Zs and fixture checks are separate from linking, startup registration, and live gameplay.
+  State which checks ran; a lint refresh is not a regression run. Routine work needs no phase archive.
 
 
 ## Tinker completion, 2026-09-10
@@ -281,7 +282,7 @@ unresolved; keep its current first/higher-rank coefficients until evidence estab
   in-memory map alone cannot reconcile a different recipient after ordinary logout/login.
 - Verify the actual DB schema before accepting an isolated SQL fixture: action slots live in
   creature_template_spell with the composite CreatureID/Index key. A fixture copied from a proposed
-  migration can falsely approve nonexistent columns. Preserve the failed proposal and supersede it
-  with actual-schema replay. Reject conflicting or extra action slots before installation.
+  migration can falsely approve nonexistent columns. Check against the actual schema and correct the proposal.
+  Reject conflicting or extra action slots before installation; retaining failed proposals is not a routine requirement.
 - Retained Tinker proc updates use HitMask 9283 (normal/crit/block/absorb/full block). 9331 would also
   admit dodge/parry. Exercise all native hit bits and retain the scripts' positive-damage filters.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,5 +16,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
+      - run: python -B apps/codestyle/tests/test_scoped_lint.py
       - run: python -B tools/check_repository.py
       - run: git diff --check HEAD^ HEAD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,20 +7,25 @@ AzerothCore is a C++ MMORPG server emulator for World of Warcraft 3.3.5a (WotLK)
 - **Do not configure or build unless explicitly asked.** Builds are slow and rarely needed for code changes.
 - **Never edit SQL files outside `data/sql/updates/pending_db_*/` unless explicitly requested.** `data/sql/base/`, `data/sql/archive/`, and `data/sql/updates/db_*/` are immutable.
 - Formatting follows `.editorconfig`: UTF-8, LF, max 120 cols, trailing newline, no trailing whitespace; 4-space indent for C++ (tabs forbidden), 2-space for JSON/YAML/sh/ts/js.
-- Planning docs go in `.agents/plans/<task-slug>/` (gitignored), named `<task-slug>.<TYPE>.md` (`PLAN`, `REQUIREMENTS`, `ANALYSIS`, …).
+- Keep ordinary plans and results in the conversation. If a planning document is requested or necessary,
+  use `.agents/plans/<task-slug>/` (gitignored); no per-task document is required.
+- Use existing tools and the smallest relevant checks. Routine edits need no source snapshots, backup folders,
+  receipts, or standalone reports. Preserve unique untracked work and use Git diffs for tracked files.
+- A source-only task ends with the requested change and relevant checks. Builds, deployment, and in-game
+  acceptance are separate scopes. Repeat passing checks only after changes or a specific unresolved concern.
 
-## Mandatory reading per task
+## Task references
 
-Read the matching doc(s) BEFORE starting the task:
+Read the relevant sections when needed for the work. Do not read every guide or turn examples into extra tasks.
 
-- Compiling, configuring, or running tests → `.agents/docs/build.md`
+- Authorized CMake configuration/build or native test setup → `.agents/docs/build.md`
 - Writing or modifying C++ → `.agents/docs/cpp-guidelines.md`
   - Script work (under `src/server/scripts/`) → also `.agents/docs/cpp-scripts.md`
 - Creating or modifying SQL → `.agents/docs/sql-guidelines.md`
   - SmartAI work (`smart_scripts` data) → also `.agents/docs/cpp-scripts.md`
 - Reviewing a changeset or PR → `.agents/docs/code-review.md`
-- Self-reviewing, or opening or updating a PR → also `.agents/docs/self-review-rules.md`
-- Touching a subsystem that has a doc in `.agents/docs/systems/` → read that doc too
+- Preparing an actual PR → `.agents/docs/self-review-rules.md`
+- Subsystem-specific questions → the relevant section in `.agents/docs/systems/`
 - Ascension damage/healing, AP/RAP/SP coefficients, triggered spells or tooltip parity →
   `.agents/docs/systems/ascension-spell-parity.md`
 - Local SQL/binary/client deployment, MPQ synchronization or deployment-verifier tests →
@@ -50,6 +55,7 @@ In this private fork, `modules/mod-ascension-compat` is vendored into this repos
 or a separate working tree. `origin` is the private CoA fork; `upstream` is the original AzerothCore
 repository. Fetching upstream is separate from reviewing, merging, building or deploying its changes.
 
-## Persisting lessons
+## Maintaining guidance
 
-When a user correction reveals a lesson that generalizes, offer to persist it into these docs (placement per `.agents/docs/README.md`): use the `/self-improve` skill if installed, otherwise suggest the user to install it and read this page: https://www.azerothcore.org/wiki/agentic-engineering
+Keep only stable conventions and essential routing here. Update guidance when requested or when a durable
+correction is needed; do not automatically offer lesson capture, install skills, or append task histories.

--- a/apps/codestyle/codestyle-cpp.py
+++ b/apps/codestyle/codestyle-cpp.py
@@ -1,3 +1,4 @@
+import argparse
 import io
 import os
 import sys
@@ -45,13 +46,16 @@ results = {
 }
 
 # Main function to parse all the files of the project
-def parsing_file(directory: str) -> None:
+def parsing_file(directory: str, selected_files=None) -> None:
     print("Starting AzerothCore CPP Codestyle check...")
     print(" ")
     print("Please read the C++ Code Standards for AzerothCore:")
     print("https://www.azerothcore.org/wiki/cpp-code-standards")
     print(" ")
-    for root, _, files in os.walk(directory):
+    file_groups = os.walk(directory) if selected_files is None else (
+        (os.path.dirname(path), [], [os.path.basename(path)]) for path in selected_files
+    )
+    for root, _, files in file_groups:
         for file in files:
             if not file.endswith('.ico'):                                   # Skip .ico files that cannot be read
                 file_path = os.path.join(root, file)
@@ -295,5 +299,16 @@ def misc_codestyle_check(file: io, file_path: str) -> None:
         error_handler = True
         results["Misc codestyle check"] = "Failed"
 
-# Main function
-parsing_file(src_directory)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check C++ codestyle; defaults to the full src tree.")
+    parser.add_argument("--files", nargs="+", metavar="PATH", help="Check only the supplied files.")
+    args = parser.parse_args()
+    if args.files:
+        for path in args.files:
+            if not os.path.isfile(path):
+                parser.error(f"File does not exist: {path}")
+    parsing_file(src_directory, args.files)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/codestyle/codestyle-sql.py
+++ b/apps/codestyle/codestyle-sql.py
@@ -1,3 +1,4 @@
+import argparse
 import io
 import os
 import sys
@@ -10,14 +11,6 @@ base_dir = os.getcwd()
 # Get the pending directory of the project
 pattern = os.path.join(base_dir, 'data/sql/updates/pending_db_*')
 src_directory = glob.glob(pattern)
-
-# Get files from base dir
-base_pattern = os.path.join(base_dir, 'data/sql/base/db_*')
-base_directory = glob.glob(base_pattern)
-
-# Get files from archive dir
-archive_pattern = os.path.join(base_dir, 'data/sql/archive/db_*')
-archive_directory = glob.glob(archive_pattern)
 
 # Global variables
 error_handler = False
@@ -42,26 +35,31 @@ def collect_files_from_directories(directories: list) -> list:
                     all_files.append(os.path.join(root, file))
     return all_files
 
-# Used to find changed or added files compared to main.
-def get_changed_files() -> list:
-    subprocess.run(["git", "fetch", "origin", "main"], check=True)
+# Resolve local refs only: linting must not fetch or depend on a remote being available.
+def get_changed_files(base=None) -> list:
+    candidates = [base] if base else ["origin/HEAD", "origin/main", "origin/master", "main", "master", "HEAD"]
+    revision = None
+    for candidate in candidates:
+        resolved = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", "--end-of-options", f"{candidate}^{{commit}}"],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        if resolved.returncode == 0:
+            revision = resolved.stdout.strip()
+            break
+    if revision is None:
+        raise ValueError(f"No local comparison ref found for {base or 'the default branch'}; use --files or --base.")
     result = subprocess.run(
-        ["git", "diff", "--name-status", "origin/main"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "-z", revision, "--"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        check=True,
     )
-    changed_files = []
-    for line in result.stdout.strip().splitlines():
-        if not line:
-            continue
-        status, path = line.split(maxsplit=1)
-        if status in ("A", "M"):
-            changed_files.append(path)
-    return changed_files
+    return [path for path in result.stdout.split("\0") if path.lower().endswith(".sql")]
 
 # Main function to parse all the files of the project
-def parsing_file(files: list) -> None:
+def parsing_file(files: list, changed_files=None) -> None:
     print("Starting AzerothCore SQL Codestyle check...")
     print(" ")
     print("Please read the SQL Standards for AzerothCore:")
@@ -70,7 +68,8 @@ def parsing_file(files: list) -> None:
 
     # Iterate over all files in data/sql/updates/pending_db_*
     for file_path in files:
-        if "base" not in file_path and "archive" not in file_path:
+        path_parts = os.path.normpath(file_path).split(os.sep)
+        if "base" not in path_parts and "archive" not in path_parts:
             try:
                 with open(file_path, 'r', encoding='utf-8') as file:
                     multiple_blank_lines_check(file, file_path)
@@ -85,10 +84,12 @@ def parsing_file(files: list) -> None:
                 sys.exit(1)
 
     # Make sure we only check changed or added files when we work with base/archive paths
-    changed_files = get_changed_files()
+    if changed_files is None:
+        changed_files = get_changed_files()
     # Iterate over all file paths
     for file_path in changed_files:
-        if "base" in file_path or "archive" in file_path:
+        path_parts = os.path.normpath(file_path).split(os.sep)
+        if "base" in path_parts or "archive" in path_parts:
             try:
                 with open(file_path, "r", encoding="utf-8") as f:
                     directory_check(f, file_path)
@@ -455,8 +456,25 @@ def non_innodb_engine_check(file: io, file_path: str) -> None:
         error_handler = True
         results["Table engine check"] = "Failed"    
 
-# Collect all files from matching directories
-all_files = collect_files_from_directories(src_directory) + collect_files_from_directories(base_directory) + collect_files_from_directories(archive_directory)
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check SQL codestyle without network access.")
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument("--files", nargs="+", metavar="PATH", help="Check only the supplied SQL files.")
+    selection.add_argument("--base", metavar="REF", help="Check SQL changes against this locally available ref.")
+    args = parser.parse_args()
+    try:
+        if args.files:
+            for path in args.files:
+                if not os.path.isfile(path) or not path.lower().endswith(".sql"):
+                    parser.error(f"Expected an existing SQL file: {path}")
+            parsing_file(args.files, args.files)
+        else:
+            changed_files = get_changed_files(args.base)
+            files = changed_files if args.base else collect_files_from_directories(src_directory)
+            parsing_file(files, changed_files)
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        parser.error(str(error))
 
-# Main function
-parsing_file(all_files)
+
+if __name__ == "__main__":
+    main()

--- a/apps/codestyle/tests/test_scoped_lint.py
+++ b/apps/codestyle/tests/test_scoped_lint.py
@@ -1,0 +1,113 @@
+"""Exercise scoped lint selection and protected SQL paths in disposable repositories."""
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+GOOD_SQL = "SELECT 1;\n"
+BAD_SQL = "SELECT 1;;\n"
+
+
+class ScopedLintTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory(prefix="scoped-lint-")
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "database-work"
+        self.root.mkdir()
+        self.pending = "data/sql/updates/pending_db_world/"
+        self.put(self.pending + "selected.sql", GOOD_SQL)
+        self.put(self.pending + "unrelated.sql", BAD_SQL)
+        self.put("src/selected.cpp", "int value = 1;\n")
+        self.put("src/unrelated.cpp", "int value = 1;;\n")
+        self.git("init", "--quiet", "--initial-branch=main")
+        self.git("add", ".")
+        self.git("-c", "user.name=Lint Tests", "-c", "user.email=lint-tests@example.invalid",
+                 "commit", "--quiet", "-m", "Baseline")
+
+    def put(self, relative, text):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+        return path
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, check=True, capture_output=True,
+                              text=True, encoding="utf-8")
+
+    def lint(self, language, *args):
+        return subprocess.run([sys.executable, "-B", "-X", "utf8",
+                               str(SCRIPTS / ("codestyle-" + language + ".py")), *args],
+                              cwd=self.root, capture_output=True, text=True, encoding="utf-8", timeout=20)
+
+    def assert_passes(self, result):
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_cpp_files_ignores_unselected_errors_and_default_still_scans(self):
+        self.assert_passes(self.lint("cpp", "--files", "src/selected.cpp"))
+        result = self.lint("cpp")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unrelated.cpp", result.stdout)
+
+    def test_cpp_selected_file_keeps_style_checks(self):
+        result = self.lint("cpp", "--files", "src/unrelated.cpp")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Double semicolon", result.stdout)
+
+    def test_sql_files_works_without_git_and_handles_spaces(self):
+        path = self.put(self.pending + "selected migration.sql", GOOD_SQL)
+        # Explicit files never need git, a local ref, or a remote connection.
+        environment = dict(os.environ, PATH="")
+        result = subprocess.run([sys.executable, "-B", "-X", "utf8",
+                                 str(SCRIPTS / "codestyle-sql.py"), "--files", str(path)],
+                                cwd=self.root, env=environment, capture_output=True,
+                                text=True, encoding="utf-8", timeout=20)
+        self.assert_passes(result)
+
+    def test_sql_local_base_limits_selection_and_default_still_scans(self):
+        self.put(self.pending + "selected.sql", "SELECT 2;\n")
+        self.assert_passes(self.lint("sql", "--base", "main"))
+        result = self.lint("sql")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unrelated.sql", result.stdout)
+
+    def test_sql_selected_file_keeps_style_checks(self):
+        result = self.lint("sql", "--files", self.pending + "unrelated.sql")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SQL codestyle check : Failed", result.stdout)
+
+    def test_sql_base_handles_renames_additions_and_deletions(self):
+        self.git("mv", self.pending + "selected.sql", self.pending + "renamed migration.sql")
+        self.put(self.pending + "added.sql", GOOD_SQL)
+        self.git("add", self.pending + "added.sql")
+        self.git("rm", self.pending + "unrelated.sql")
+        self.assert_passes(self.lint("sql", "--base", "main"))
+        self.put(self.pending + "added.sql", BAD_SQL)
+        self.assertNotEqual(self.lint("sql", "--base", "main").returncode, 0)
+
+    def test_sql_protected_directories_remain_rejected(self):
+        for directory in ("base", "archive"):
+            relative = "data/sql/" + directory + "/db_world/template.sql"
+            self.put(relative, GOOD_SQL)
+            result = self.lint("sql", "--files", relative)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Directory check : Failed", result.stdout)
+            self.git("add", relative)
+        self.assertNotEqual(self.lint("sql", "--base", "main").returncode, 0)
+
+    def test_invalid_inputs_fail_clearly(self):
+        for language in ("cpp", "sql"):
+            result = self.lint(language, "--files", "missing.file")
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("error:", result.stderr)
+        result = self.lint("sql", "--base", "missing-ref")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("No local comparison ref", result.stderr)
+        self.assertEqual(self.lint("sql", "--files", self.pending + "selected.sql",
+                                   "--base", "main").returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem and resulting behavior

Routine checks currently scan broad source/SQL trees, and SQL lint fetches origin/main even when checking local work. Add --files to both linters and --base to SQL lint, resolving comparison refs locally without network access. Selected files retain the existing style and SQL-directory checks, while no-argument commands retain broad checking.

Update the agent guidance to use relevant checks and references, distinguish source work from builds/deployment/gameplay acceptance, and keep ordinary plans and results in the conversation. Retain the explicit build authorization, immutable SQL, process identity, rollback, and player-data protections.

## Validation and remaining limits

- Eight regression tests passed in disposable Git repositories: selected versus broad scans, style failures, filenames with spaces, operation without Git for --files, local-base selection, additions/renames/deletions, protected SQL directories, and invalid arguments.
- The regression suite is added to the repository's CI workflow.
- Repository publication checks and git diff --check passed.
- No server build, deployment, or gameplay test was needed for these tooling/documentation changes.

## Data/source dependencies

No new Python dependencies. SQL --base requires an existing local Git ref; --files works without Git or a network connection.

Existing applied SQL is unchanged. No credentials, profiles, runtime configuration, binaries, game data, or archives are included.

- [x] AI assistance: Codex (GPT-6) reviewed the existing edits, added regression tests and their CI step, and prepared this PR.
