### PR TITLE
fix(Core): Restore login and natural regeneration

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           python-version: '3.12'
       - run: python -B apps/codestyle/tests/test_scoped_lint.py
+      - run: python -B modules/mod-ascension-compat/tests/client_compat/run.py
       - run: python -B tools/check_repository.py
       - run: git diff --check HEAD^ HEAD

--- a/modules/mod-ascension-compat/README.md
+++ b/modules/mod-ascension-compat/README.md
@@ -20,3 +20,28 @@ directory, preserve applied SQL hashes, and follow
 `.agents/docs/systems/ascension-local-deployment.md` in the server checkout.
 Do not run historical installers or clear client caches to compensate for a
 protocol, data or process problem.
+
+## Login and natural regeneration
+
+The copied client's `Extensions.dll` patches the ping timer at executable address
+`0x632DE5` from -30000 to -5000 milliseconds (DLL write at `0x10A689AC`). The inspected
+DLL SHA-256 is `f7b713095aab17a1e376f487290d4b7c4c18931635e4d91136d76db2592be8fa`.
+Stock AzerothCore counts pings less than 27 seconds apart as overspeed; ordinary
+accounts are disconnected after exceeding `MaxOverspeedPings`, while GM permission
+23 bypasses that check. Local connections with `AscensionCompat.Enable = 1` accept
+the five-second cadence with a one-second jitter margin. Faster sustained flooding
+still reaches the strike limit. Other connections retain the stock limit.
+
+The `gtOCTRegenHP`, `gtRegenHPPerSpt` and `gtRegenMPPerSpt` client files each contain
+3,200 single-float rows indexed by class and level. Their SQL tables contain explicit
+IDs, with the stock dataset covering only IDs 0–1099. The DBC loader accepts implicit
+row IDs for these game tables while preserving explicit-ID files and SQL overrides.
+This lets the existing regeneration formulas reach the supplied custom-class rows;
+focus and energy use separate formulas.
+
+Run `python -B modules/mod-ascension-compat/tests/client_compat/run.py` with a C++20
+compiler available. `--dbc-dir <server-data/dbc>` also compares every installed
+regeneration coefficient with the native loader's result. The tests compile the
+actual storage/loader and ping/regeneration methods, using isolated session, clock
+and database boundaries. They do not launch the server or client. Rebuilding and
+deploying the corrected server is required before checking real logins and gameplay.

--- a/modules/mod-ascension-compat/tests/client_compat/harness.cpp
+++ b/modules/mod-ascension-compat/tests/client_compat/harness.cpp
@@ -1,0 +1,265 @@
+#include "DBCStore.h"
+#include "DBCDatabaseLoader.h"
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <utility>
+
+namespace
+{
+int failures = 0;
+int checks = 0;
+void Check(bool value, char const* name)
+{
+    ++checks;
+    failures += !value;
+    std::cout << (value ? "PASS: " : "FAIL: ") << name << '\n';
+}
+}
+
+// The database boundary deliberately supplies one explicit-ID overlay.
+DBCDatabaseLoader::DBCDatabaseLoader(char const*, char const* format, std::vector<char*>& pool)
+    : _sqlTableName(nullptr), _dbcFormat(format), _sqlIndexPos(0), _recordSize(4), _stringPool(pool) { }
+char* DBCDatabaseLoader::Load(uint32& records, char**& index)
+{
+    assert(std::strcmp(_dbcFormat, "df") == 0 && records == 3200);
+    char* row = new char[sizeof(float)];
+    float value = 900.0f;
+    std::memcpy(row, &value, sizeof(value));
+    index[0] = row;
+    return row;
+}
+
+struct GtOCTRegenHPEntry { float ratio; };
+struct GtRegenHPPerSptEntry { float ratio; };
+struct GtRegenMPPerSptEntry { float ratio; };
+DBCStorage<GtOCTRegenHPEntry> sGtOCTRegenHPStore("df");
+DBCStorage<GtRegenHPPerSptEntry> sGtRegenHPPerSptStore("df");
+DBCStorage<GtRegenMPPerSptEntry> sGtRegenMPPerSptStore("df");
+constexpr uint32 GT_MAX_LEVEL = 100;
+constexpr uint32 STAT_SPIRIT = 4;
+struct Player
+{
+    uint8 Class = 23;
+    uint8 Level = 80;
+    float Spirit = 100;
+    uint8 GetLevel() const { return Level; }
+    uint8 getClass() const { return Class; }
+    float GetStat(uint32) const { return Spirit; }
+    float OCTRegenHPPerSpirit();
+    float OCTRegenMPPerSpirit();
+};
+// ACTUAL_HP_REGEN
+// ACTUAL_MP_REGEN
+
+template<class T>
+bool VerifyFile(DBCStorage<T>& store, std::string const& path)
+{
+    if (!store.Load(path.c_str()))
+        return false;
+    std::ifstream input(path, std::ios::binary);
+    uint32 header[5];
+    input.read(reinterpret_cast<char*>(header), sizeof(header));
+    if (header[2] != 1 || header[3] != 4 || header[1] != store.GetNumRows())
+        return false;
+    for (uint32 i = 0; i < header[1]; ++i)
+    {
+        float value;
+        input.read(reinterpret_cast<char*>(&value), sizeof(value));
+        if (!input || !store.LookupEntry(i) || store.LookupEntry(i)->ratio != value)
+            return false;
+    }
+    return !store.LookupEntry(header[1]);
+}
+
+void TestDBC(std::string const& folder, bool installed)
+{
+    // Globals are loaded once. Additional installed-file checks use separate stores.
+    if (installed)
+    {
+        DBCStorage<GtOCTRegenHPEntry> hp("df");
+        DBCStorage<GtRegenHPPerSptEntry> spirit("df");
+        DBCStorage<GtRegenMPPerSptEntry> mana("df");
+        Check(VerifyFile(hp, folder + "/gtOCTRegenHP.dbc") &&
+            VerifyFile(spirit, folder + "/gtRegenHPPerSpt.dbc") &&
+            VerifyFile(mana, folder + "/gtRegenMPPerSpt.dbc"), "all installed regeneration coefficients load exactly");
+        return;
+    }
+    bool loaded = VerifyFile(sGtOCTRegenHPStore, folder + "/gtOCTRegenHP.dbc") &&
+        VerifyFile(sGtRegenHPPerSptStore, folder + "/gtRegenHPPerSpt.dbc") &&
+        VerifyFile(sGtRegenMPPerSptStore, folder + "/gtRegenMPPerSpt.dbc");
+    Check(loaded, "implicit row IDs retain all 32 classes and valid zero coefficients");
+    if (loaded)
+    {
+        bool formulas = true;
+        Player player;
+        for (uint8 classId = 1; classId <= 32; ++classId)
+            for (uint8 level : {1, 10, 80, 100, 101})
+            {
+                player.Class = classId;
+                player.Level = level;
+                player.Spirit = 100;
+                formulas &= player.OCTRegenHPPerSpirit() == 75.0f;
+                formulas &= std::fabs(player.OCTRegenMPPerSpirit() - (classId == 12 ? 0.0f : 1.0f)) < 0.00001f;
+                player.Spirit = 25;
+                formulas &= player.OCTRegenHPPerSpirit() == 12.5f;
+            }
+        Check(formulas, "native regeneration formulas, spirit breakpoint and level cap for every class");
+        player.Class = 33;
+        Check(player.OCTRegenHPPerSpirit() == 0 && player.OCTRegenMPPerSpirit() == 0,
+            "missing classes remain safely handled");
+        sGtOCTRegenHPStore.LoadFromDB("test_overlay", sGtOCTRegenHPStore.GetFormat());
+        Check(sGtOCTRegenHPStore.LookupEntry(0)->ratio == 900.0f &&
+            sGtOCTRegenHPStore.LookupEntry(3199)->ratio == 0.25f,
+            "SQL keeps explicit IDs and overrides existing rows without losing custom classes");
+    }
+    DBCStorage<GtOCTRegenHPEntry> indexed("df");
+    Check(indexed.Load((folder + "/indexed.dbc").c_str()) && indexed.GetNumRows() == 8 &&
+        !indexed.LookupEntry(0) && indexed.LookupEntry(2)->ratio == 1.5f && indexed.LookupEntry(7)->ratio == 2.5f,
+        "explicit sparse-ID files retain their original layout");
+    DBCStorage<GtOCTRegenHPEntry> invalid("df");
+    Check(!invalid.Load((folder + "/invalid.dbc").c_str()), "invalid float record size is rejected");
+}
+
+// Control arrival times while executing the unchanged native ping handler.
+struct TestClock
+{
+    using duration = std::chrono::steady_clock::duration;
+    using time_point = std::chrono::time_point<TestClock>;
+    static inline time_point Current{std::chrono::seconds(100)};
+    static time_point now() { return Current; }
+};
+using TimePoint = TestClock::time_point;
+#define steady_clock TestClock
+#define LOG_ERROR(...) ((void)0)
+constexpr uint32 CONFIG_MAX_OVERSPEED_PINGS = 0;
+constexpr uint32 SMSG_PONG = 1;
+namespace rbac { constexpr uint32 RBAC_PERM_SKIP_CHECK_OVERSPEED_PING = 23; }
+struct World
+{
+    uint32 MaxStrikes = 2;
+    uint32 getIntConfig(uint32) const { return MaxStrikes; }
+} world;
+World* sWorld = &world;
+struct Config
+{
+    bool Enabled = false;
+    template<class T> T GetOption(char const* name, T) const
+    {
+        assert(std::strcmp(name, "AscensionCompat.Enable") == 0);
+        return T(Enabled);
+    }
+} config;
+Config* sConfigMgr = &config;
+struct WorldSession
+{
+    bool GM = false;
+    uint32 Latency = 0;
+    bool HasPermission(uint32) const { return GM; }
+    void SetLatency(uint32 value) { Latency = value; }
+};
+struct WorldPacket
+{
+    uint32 Values[2]{0, 42};
+    uint32 Position = 0;
+    WorldPacket() = default;
+    WorldPacket(uint32, uint32) { }
+    WorldPacket& operator>>(uint32& value) { value = Values[Position++]; return *this; }
+    WorldPacket& operator<<(uint32) { return *this; }
+};
+struct IoContextTcpSocket { bool Loopback; };
+struct Socket
+{
+    bool Loopback;
+    explicit Socket(IoContextTcpSocket&& socket) : Loopback(socket.Loopback) { }
+    Socket const& GetRemoteIpAddress() const { return *this; }
+    bool is_loopback() const { return Loopback; }
+};
+namespace Acore::Crypto { void GetRandomBytes(std::array<uint8, 4>&) { } }
+struct ClientPktHeader { uint32 Value; };
+struct WorldSocket : Socket
+{
+    explicit WorldSocket(IoContextTcpSocket&& socket);
+    bool HandlePing(WorldPacket& packet);
+    std::array<uint8, 4> _authSeed{};
+    // ACTUAL_PING_STATE
+    std::mutex _worldSessionLock;
+    WorldSession* _worldSession;
+    bool _authed;
+    std::size_t _sendBufferSize;
+    bool _loggingPackets;
+    bool _loggedFirstClientHeader;
+    struct Buffer { void Resize(std::size_t) { } } _headerBuffer;
+    uint32 Pongs = 0;
+    void SendPacketAndLogOpcode(WorldPacket const&) { ++Pongs; }
+};
+// ACTUAL_SOCKET_CONSTRUCTOR
+// ACTUAL_PING
+#undef steady_clock
+
+bool Ping(WorldSocket& socket, std::chrono::milliseconds elapsed)
+{
+    TestClock::Current += elapsed;
+    WorldPacket packet;
+    return socket.HandlePing(packet);
+}
+
+void TestPing(bool enabled, bool loopback, bool gm, bool expected)
+{
+    using namespace std::chrono_literals;
+    config.Enabled = enabled;
+    WorldSession session;
+    session.GM = gm;
+    WorldSocket socket(IoContextTcpSocket{loopback});
+    socket._worldSession = &session;
+    bool connected = Ping(socket, 0ms);
+    for (int i = 0; i < 24 && connected; ++i)
+        connected = Ping(socket, 5s);
+    Check(connected == expected && session.Latency == 42,
+        enabled && loopback && !gm ? "ordinary Ascension account accepts two minutes of five-second pings" :
+        gm ? "existing GM permission remains effective" : "stock and remote sessions retain the 27-second limit");
+}
+
+void TestFlood()
+{
+    using namespace std::chrono_literals;
+    config.Enabled = true;
+    WorldSession session;
+    WorldSocket socket(IoContextTcpSocket{true});
+    socket._worldSession = &session;
+    Check(Ping(socket, 0ms) && Ping(socket, 1s) && Ping(socket, 1s) && !Ping(socket, 1s),
+        "ordinary Ascension accounts are still disconnected for sustained ping flooding");
+    WorldSocket recovered(IoContextTcpSocket{true});
+    recovered._worldSession = &session;
+    Check(Ping(recovered, 0ms) && Ping(recovered, 1s) && Ping(recovered, 1s) && Ping(recovered, 4s) &&
+        Ping(recovered, 1s), "jitter margin and good intervals reset overspeed strikes");
+    config.Enabled = false;
+    Check(Ping(recovered, 5s) && Ping(recovered, 5s), "ping compatibility is cached per connection");
+    WorldSocket stock(IoContextTcpSocket{true});
+    stock._worldSession = &session;
+    Check(Ping(stock, 0ms) && Ping(stock, 30s) && Ping(stock, 27s), "ordinary stock ping cadence is accepted");
+    sWorld->MaxStrikes = 0;
+    Check(Ping(stock, 1ms) && Ping(stock, 1ms) && Ping(stock, 1ms) && Ping(stock, 1ms),
+        "configured disabled overspeed enforcement remains effective");
+    sWorld->MaxStrikes = 2;
+    WorldSocket unauthenticated(IoContextTcpSocket{true});
+    Check(!Ping(unauthenticated, 0ms), "unauthenticated pings remain rejected");
+}
+
+int main(int argc, char** argv)
+{
+    assert(argc >= 2);
+    TestDBC(argv[1], false);
+    if (argc > 2)
+        TestDBC(argv[2], true);
+    TestPing(true, true, false, true);
+    TestPing(false, true, false, false);
+    TestPing(true, false, false, false);
+    TestPing(false, true, true, true);
+    TestFlood();
+    std::cout << checks - failures << '/' << checks << " checks passed\n";
+    return failures ? 1 : 0;
+}

--- a/modules/mod-ascension-compat/tests/client_compat/run.py
+++ b/modules/mod-ascension-compat/tests/client_compat/run.py
@@ -1,0 +1,108 @@
+"""Run native DBC loading and ping regressions without a server or database.
+
+Uses the real DBC storage/loader and Player regeneration/WorldSocket ping methods.
+Only database overlays, sessions, configuration and the clock are isolated.
+Pass --dbc-dir to additionally verify the installed regeneration tables.
+"""
+
+import argparse
+import os
+from pathlib import Path
+import shutil
+import struct
+import subprocess
+import tempfile
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[3]
+
+
+def method(source, signature):
+    start = source.index(signature)
+    end = source.index('{', start) + 1
+    depth = 1
+    while depth:
+        depth += (source[end] == '{') - (source[end] == '}')
+        end += 1
+    return source[start:end]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dbc-dir', type=Path)
+    parser.add_argument('--source-ref', help='Read changed production code from a local Git ref for regression checks.')
+    args = parser.parse_args()
+
+    def source(name):
+        if args.source_ref:
+            return subprocess.check_output(['git', 'show', f'{args.source_ref}:{name}'], cwd=ROOT).decode('utf-8')
+        return (ROOT / name).read_text(encoding='utf-8')
+
+    socket = source('src/server/game/Server/WorldSocket.cpp')
+    socket_header = source('src/server/game/Server/WorldSocket.h')
+    player = source('src/server/game/Entities/Player/Player.cpp')
+    harness = (HERE / 'harness.cpp').read_text(encoding='utf-8')
+    for marker, text in [
+        ('PING_STATE', socket_header[socket_header.index('    TimePoint _LastPingTime;'):
+                                     socket_header.index('    std::mutex _worldSessionLock;')]),
+        ('SOCKET_CONSTRUCTOR', method(socket, 'WorldSocket::WorldSocket(')),
+        ('PING', method(socket, 'bool WorldSocket::HandlePing(')),
+        ('HP_REGEN', method(player, 'float Player::OCTRegenHPPerSpirit(')),
+        ('MP_REGEN', method(player, 'float Player::OCTRegenMPPerSpirit(')),
+    ]:
+        harness = harness.replace('// ACTUAL_' + marker, text)
+
+    compiler = shutil.which(os.environ.get('CXX', 'cl.exe' if os.name == 'nt' else 'c++'))
+    assert compiler, 'Enable a C++20 compiler (VS Developer PowerShell on Windows).'
+    with tempfile.TemporaryDirectory(prefix='coa-client-compat-') as directory:
+        out = Path(directory)
+        (out / 'Define.h').write_text('''#pragma once
+#include <cstdint>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <iterator>
+#include <string>
+using uint8 = std::uint8_t;
+using int8 = std::int8_t;
+using uint16 = std::uint16_t;
+using uint32 = std::uint32_t;
+using int32 = std::int32_t;
+#define ACORE_ENDIAN 0
+#define ACORE_BIGENDIAN 1
+''', encoding='utf-8')
+        (out / 'Common.h').write_text('#pragma once\n#include "Define.h"\n', encoding='utf-8')
+        (out / 'Errors.h').write_text('''#pragma once
+#include <cassert>
+#define ASSERT(condition, ...) assert(condition)
+#define ASSERT_NOTNULL(value) (assert(value), (value))
+''', encoding='utf-8')
+        (out / 'DBCStore.cpp').write_text(source('src/server/shared/DataStores/DBCStore.cpp'), encoding='utf-8')
+        (out / 'harness.cpp').write_text(harness, encoding='utf-8')
+        # Implicit row IDs, including valid zero mana coefficients for non-mana classes.
+        for name, ratio in [('gtOCTRegenHP.dbc', 0.25), ('gtRegenHPPerSpt.dbc', 0.5),
+                            ('gtRegenMPPerSpt.dbc', 0.01)]:
+            values = [0.0 if name == 'gtRegenMPPerSpt.dbc' and i // 100 == 11 else ratio
+                      for i in range(3200)]
+            (out / name).write_bytes(struct.pack('<4s4I', b'WDBC', 3200, 1, 4, 0)
+                                    + struct.pack('<3200f', *values))
+        (out / 'indexed.dbc').write_bytes(struct.pack('<4s4IIfIf', b'WDBC', 2, 2, 8, 0, 2, 1.5, 7, 2.5))
+        # Do not mistake a malformed, padded record for an implicit-index float table.
+        (out / 'invalid.dbc').write_bytes(struct.pack('<4s4I2f', b'WDBC', 1, 1, 8, 0, 1.0, 2.0))
+        includes = [out, ROOT / 'src/server/shared/DataStores', ROOT / 'src/common/DataStores', ROOT / 'src/common']
+        sources = [out / 'harness.cpp', out / 'DBCStore.cpp', ROOT / 'src/common/DataStores/DBCFileLoader.cpp']
+        executable = out / ('regressions.exe' if os.name == 'nt' else 'regressions')
+        if Path(compiler).stem.lower() == 'cl':
+            flags = ['/nologo', '/std:c++20', '/EHsc', '/utf-8', '/D_CRT_SECURE_NO_WARNINGS',
+                     *['/I' + str(p) for p in includes], *map(str, sources), '/Fe' + str(executable)]
+        else:
+            flags = ['-std=c++20', *['-I' + str(p) for p in includes], *map(str, sources), '-o', str(executable)]
+        subprocess.run([compiler, *flags], cwd=out, check=True)
+        command = [str(executable), str(out)]
+        if args.dbc_dir:
+            command.append(str(args.dbc_dir.resolve()))
+        subprocess.run(command, cwd=out, check=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -124,6 +124,11 @@ WorldSocket::WorldSocket(IoContextTcpSocket&& socket)
 {
     Acore::Crypto::GetRandomBytes(_authSeed);
     _headerBuffer.Resize(sizeof(ClientPktHeader));
+
+    // Extensions.dll changes the local Ascension client's ping period to five seconds.
+    // Allow one second of jitter while retaining the ordinary overspeed strike limit.
+    if (GetRemoteIpAddress().is_loopback() && sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false))
+        _minimumPingInterval = std::chrono::seconds(4);
 }
 
 WorldSocket::~WorldSocket() = default;
@@ -820,7 +825,7 @@ bool WorldSocket::HandlePing(WorldPacket& recvPacket)
 
         _LastPingTime = now;
 
-        if (diff < seconds(27))
+        if (diff < _minimumPingInterval)
         {
             ++_OverSpeedPings;
 
@@ -832,8 +837,10 @@ bool WorldSocket::HandlePing(WorldPacket& recvPacket)
 
                 if (_worldSession && !_worldSession->HasPermission(rbac::RBAC_PERM_SKIP_CHECK_OVERSPEED_PING))
                 {
-                    LOG_ERROR("network", "WorldSocket::HandlePing: {} kicked for over-speed pings (address: {})",
-                        _worldSession->GetPlayerInfo(), GetRemoteIpAddress().to_string());
+                    LOG_ERROR("network", "WorldSocket::HandlePing: {} kicked for over-speed pings "
+                        "(address: {}, interval: {} ms, minimum: {} ms)", _worldSession->GetPlayerInfo(),
+                        GetRemoteIpAddress().to_string(), duration_cast<milliseconds>(diff).count(),
+                        duration_cast<milliseconds>(_minimumPingInterval).count());
 
                     return false;
                 }

--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -124,6 +124,7 @@ private:
 
     TimePoint _LastPingTime;
     uint32 _OverSpeedPings;
+    std::chrono::seconds _minimumPingInterval{27};
 
     std::mutex _worldSessionLock;
     WorldSession* _worldSession;

--- a/src/server/shared/DataStores/DBCStore.cpp
+++ b/src/server/shared/DataStores/DBCStore.cpp
@@ -18,6 +18,19 @@
 #include "DBCStore.h"
 #include "DBCDatabaseLoader.h"
 
+namespace
+{
+char const* GetFileFormat(DBCFileLoader const& dbc, char const* format)
+{
+    // Game-table DBCs contain one float per row; the row number is the ID.
+    // Their SQL overlays add an explicit ID column and still require "df".
+    if (std::strcmp(format, "df") == 0 && dbc.GetCols() == 1 && dbc.GetRowSize() == sizeof(float))
+        return "f";
+
+    return format;
+}
+}
+
 DBCStorageBase::DBCStorageBase(char const* fmt) : _fieldCount(0), _fileFormat(fmt), _dataTable(nullptr), _indexTableSize(0)
 {
 }
@@ -40,12 +53,13 @@ bool DBCStorageBase::Load(char const* path, char**& indexTable)
         return false;
 
     _fieldCount = dbc.GetCols();
+    char const* fileFormat = GetFileFormat(dbc, _fileFormat);
 
     // load raw non-string data
-    _dataTable = dbc.AutoProduceData(_fileFormat, _indexTableSize, indexTable);
+    _dataTable = dbc.AutoProduceData(fileFormat, _indexTableSize, indexTable);
 
     // load strings from dbc data
-    if (char* stringBlock = dbc.AutoProduceStrings(_fileFormat, _dataTable))
+    if (char* stringBlock = dbc.AutoProduceStrings(fileFormat, _dataTable))
         _stringPool.push_back(stringBlock);
 
     // error in dbc file at loading if nullptr
@@ -65,7 +79,7 @@ bool DBCStorageBase::LoadStringsFrom(char const* path, char** indexTable)
         return false;
 
     // load strings from another locale dbc data
-    if (char* stringBlock = dbc.AutoProduceStrings(_fileFormat, _dataTable))
+    if (char* stringBlock = dbc.AutoProduceStrings(GetFileFormat(dbc, _fileFormat), _dataTable))
         _stringPool.push_back(stringBlock);
 
     return true;


### PR DESCRIPTION
## Problem and resulting behavior

New non-GM accounts were disconnected because the Ascension client sends pings every five seconds, while the stock server expects at least 27 seconds. For loopback connections with Ascension compatibility enabled, accept that cadence with one second of jitter tolerance. The overspeed strike limit remains enforced; other connections keep the stock threshold.

Natural health and mana regeneration failed for custom classes because the float-only game-table DBCs were rejected in favor of stock SQL rows. Load their implicit row IDs while preserving explicit-ID formats and SQL overlay precedence, so the client’s coefficients remain available for all 32 classes.

## Validation and remaining limits

- Native regression harness: 17/17 checks passed, including the installed 3,200-row regeneration tables, actual Player regeneration methods, ping cadence, flood rejection, GM handling and SQL overlays. Running against the previous production code reproduced the loading and ping failures.
- Scoped C++ lint, repository publication checks and `git diff --check` passed.
- RelWithDebInfo worldserver build and local startup passed, with no new startup error lines.
- The user tested the deployed build and confirmed non-GM login and idle health/mana regeneration work. The agent did not launch the game client. Remote sessions retain stock ping timing.

## Data/source dependencies

Uses the existing Ascension game-table DBCs and the five-second ping cadence verified in the local Extensions.dll. No client-file changes are needed.

Applied SQL is unchanged. No credentials, profiles or game archives are included.

AI assistance: Codex generated the code, regression tests and PR description; the user performed in-game acceptance.