### PR TITLE
docs(DB): Simplify world data documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -47,9 +47,8 @@ We have a lot of modules already made by the community, many of which can be fou
 
 ## Installation
 
-For this CoA fork, follow the [world database baseline workflow](../apps/coa-world/README.md)
-before the first worldserver startup. It installs the same world content as the CoA Repack;
-the upstream base SQL alone does not contain all harvested CoA items and quests.
+For this CoA fork, install the [world database package](../apps/coa-world/README.md)
+into an empty world schema before the first worldserver startup.
 
 Detailed installation instructions are available [here](http://www.azerothcore.org/wiki/installation).
 

--- a/apps/coa-world/README.md
+++ b/apps/coa-world/README.md
@@ -1,107 +1,54 @@
-# CoA world content
+# CoA world data tools
 
-The CoA repack contains harvested world data that a stock AzerothCore database plus this
-fork's historical migrations does not fully reproduce. `data/coa-world/baseline.json` pins
-the reviewed world-content package used for new CoA installations. Its table fingerprints
-also make differences in an existing installation visible without changing it.
+Import and check the [CoA world database package](../../data/coa-world/README.md).
+The package contains world templates, reference data, and migration metadata.
 
-This is the preserved local CoA baseline, not a claim of complete official-server parity.
-It contains world templates and reference data only. It excludes the authentication and
-character databases and three historical item-template backup tables. The migration ledger
-is retained so already incorporated migrations are not replayed against their final state;
-`updates_include` uses repository-relative paths.
+## Install
 
-## New source installations
-
-Use Python 3.11 or newer and a MySQL 8 client/server. Create an empty world schema using the
-normal database setup, then import the baseline **before the first worldserver startup**:
+Use Python 3.11 or newer and a MySQL 8 client/server. Create an empty world schema,
+then import the package **before the first worldserver startup**:
 
 ```sh
 python apps/coa-world/world_data.py verify
 python apps/coa-world/world_data.py bootstrap --defaults-file /path/to/world-client.cnf --database acore_world
 ```
 
-Use `--mysql /path/to/mysql` if the client is not on PATH. The client option file contains the
-connection details; do not put passwords in command arguments or commit the option file.
-The database name may differ from `acore_world`. Point worldserver's `SourceDirectory` at the
-checkout whose baseline you imported.
+The client option file supplies the connection settings. Use `--mysql /path/to/mysql`
+if the client is not on PATH, and `--database` to select the world schema.
+Set worldserver's `SourceDirectory` to this checkout.
 
-Bootstrap validates the entire package before writing, refuses any nonempty schema, imports
-the migration ledger last, and compares every content table after import. It does not create
-accounts or characters, run the game servers, or change client files. Continue with the normal
-server setup afterward; subsequent tracked SQL migrations use the native updater.
+Bootstrap verifies the package and imported content, and requires an empty schema.
+If an import fails, recreate that partially imported schema before retrying.
+Subsequent SQL migrations use the normal server updater.
 
-The historical SQL includes committed CRLF files. Bootstrap verifies their LF-normalized
-content against the baseline and binds covered updater hashes to the host's native text-mode
-read. This avoids replaying an old migration merely because Windows and Unix read its line
-endings differently. A real change to a covered migration is rejected, not relabelled as applied.
+## Audit
 
-If import fails, the partially populated **new** schema is left for inspection. A retry refuses
-that nonempty schema. Recreate only that disposable installation schema before retrying; never
-use bootstrap to reset or upgrade an established server.
-
-## Existing repacks and source installations
+Compare an existing world database with the package without changing it:
 
 ```sh
 python apps/coa-world/world_data.py audit --defaults-file /path/to/world-client.cnf --database acore_world
 ```
 
-Audit is read-only. It compares ordered, NULL-safe row fingerprints and reports missing tables,
-column differences, changed content, and additional tables. A difference is a review input:
-later migrations and intentional local customization can legitimately change the baseline.
-It does not automatically overwrite those changes. Updater history and server-version metadata
-are excluded from the content comparison.
+The report identifies missing tables, schema differences, changed content, and additional
+tables. Later migrations and local customizations can produce expected differences.
+Updater history and server-version metadata are excluded from the comparison.
 
-For PR #18's items, the existing repack already has populated definitions. Its fractional weapon
-damage values are retained in this baseline. Changing those values to the rounded values in a
-different client cache is a separate gameplay change. The baseline also avoids creating the
-appearance placeholders on new installations, so newly created equipment starts with the proper
-durability. Existing copies from older placeholder-based installations require a separately
-scoped upgrade that handles their saved durability; a world-template update alone does not.
+## Update the package
 
-## Maintaining the baseline
+Add content changes through `data/sql/updates/pending_db_world/` migrations.
+To refresh the package, use `export_baseline.py` with a gzip SQL snapshot containing
+`acore_world` and an isolated import of that database. Run `python apps/coa-world/export_baseline.py --help`
+for the required arguments.
 
-Make reviewed content changes through new `data/sql/updates/pending_db_world/` migrations.
-Keep the versioned baseline stable between explicit baseline releases. When advancing it:
+Verify the new package and import it into an empty test schema before committing the
+archive and `baseline.json` together.
 
-1. Apply the accepted migrations to an isolated clean world database and verify the intended
-   content changes. Keep account and character data outside this workflow.
-2. Produce a clean repack snapshot with the existing packaging tools and import its world
-   section into an isolated MySQL schema.
-3. Export a new baseline directory:
-
-   ```sh
-   python apps/coa-world/export_baseline.py --snapshot /path/to/databases.sql.gz \
-     --defaults-file /path/to/isolated-client.cnf --database reference_world \
-     --output /path/to/new-baseline --id coa-world-YYYYMMDD --repack-release RELEASE_ID
-   ```
-
-4. Verify and bootstrap the new package into another empty world schema, then run the normal
-   SQL updater and audit the content again. Review the changed table fingerprints and migration
-   identities before replacing the tracked package.
-5. Build future repack world snapshots from that accepted baseline plus the tracked migrations.
-   Do not introduce another untracked world-data import in the packaging step.
-
-The exporter records the source snapshot checksum, repository revision, repack release, per-table
-SQL checksums, and content fingerprints. ZIP timestamps are fixed for reproducibility. Both the
-package and its manifest belong in the same reviewed change. Upstream attribution remains in
-the repository's existing history and SQL migrations; the repack snapshot is the immediate
-source for this preserved content.
-
-Run the focused safety checks with:
+## Checks
 
 ```sh
 python apps/coa-world/test_world_data.py
+python apps/coa-world/test_mysql.py --mysql-bin /path/to/mysql/bin
 ```
 
-To compare a fresh repository SQL installation with the baseline and verify a complete
-baseline import, run the isolated MySQL check:
-
-```sh
-python apps/coa-world/test_mysql.py --mysql-bin /path/to/mysql/bin --report /tmp/coa-world-validation.json
-```
-
-This creates temporary databases on a private socket/named pipe with TCP disabled. It checks
-every content table, refuses a repeat import without changing data, checks current migration
-hashes for unexpected replays, and compares the two starter items with their repack values.
-It does not start worldserver or connect to an installed server.
+The MySQL check creates a temporary database server with TCP disabled, verifies the
+import and migration handling, and compares the package with the repository SQL.

--- a/data/coa-world/README.md
+++ b/data/coa-world/README.md
@@ -1,63 +1,9 @@
-# CoA world baseline: 2026-09-12
+# CoA world database package
 
-This is the world content from the clean snapshot shipped with CoA Repack release
-`client-compat-20260911`. It contains 318 tables: 315 content tables plus the three
-updater/version tables. There are 562,396 item templates and 9,464 quest templates.
+The SQL archive contains world templates, reference data, and migration metadata.
+`baseline.json` identifies the archive and records its checksums, table schemas,
+content fingerprints, and covered migrations.
 
-Use the [installation and maintenance workflow](../../apps/coa-world/README.md) to
-verify the package, import an empty world schema, or audit an existing installation.
-
-## Provenance and scope
-
-- Source: the release's `Database/Clean/databases.sql.gz`, restricted to `acore_world`.
-- Source snapshot SHA-256:
-  `c1ec932ebf64a3e37797e8887ee7573712ac25157ef16984a9c37b34f9d23ca4`.
-- Repository migration revision: `8fefb6f0ae253c25014da13eab04ba2e3d0685c0`.
-- Archive SHA-256:
-  `06a3a4d331c61cff569391369427308b70c3a5d9cdf790c44f78bbae72d8afe3`.
-- The manifest records table schemas, SQL checksums, row counts, content fingerprints,
-  and 82 covered pending/module migrations.
-
-Authentication and character databases are excluded. The three historical item-template
-backup tables listed in the manifest are excluded; active compatibility/provenance tables
-are retained. Updater paths are rewritten to repository-relative paths. Content rows retain
-the repack values, including fractional weapon damage. This is a reproducible installation
-baseline, not a claim that every harvested gameplay value has been independently verified.
-
-The initial read-only audit of the running CoA Repack matched every content table exactly.
-Its only additional tables were the three excluded historical backups.
-
-## Comparison with the source SQL
-
-A fresh import of the repository base SQL followed by 356 applicable migrations was
-compared with this baseline on isolated MySQL 8.4.9, using UTC sessions:
-
-| Content | Source SQL | Repack baseline | Difference |
-| --- | ---: | ---: | --- |
-| Item templates | 190,250 | 562,396 | 372,146 missing; 190,215 existing rows differ |
-| Quest templates | 9,464 | 9,464 | 8,459 existing rows differ |
-| Trainer spells | 6,417 | 11,156 | 4,739 missing |
-| Trainers | 126 | 127 | One missing |
-| Creature templates | 31,218 | 31,219 | One missing, plus its spawn, model and trainer binding |
-
-The source also lacks two heirloom compatibility/provenance tables with 112 rows each.
-There are 159 event rows with differing schedule timestamps: the baseline preserves the
-repack's UTC instants, including its three-hour offset from base SQL timestamp literals.
-Generated compatibility-table timestamps are ignored in this source comparison.
-
-The complete baseline import matched all content fingerprints. Repeating bootstrap was
-refused without changing content, and current migration hashes required no replays.
-Package-integrity and refusal checks also passed the nine focused unit tests.
-
-## Starter items discussed in PR #18
-
-| Entry | Name | Quality | Damage | Armor | Maximum durability |
-| --- | --- | --- | --- | --- | --- |
-| 484319 | Decayed Dagger | 1 | 0.9375–3.75 | 0 | 18 |
-| 967757 | Noxious Kilt | 0 | 0–0 | 6 | 35 |
-
-The repack already contains these populated definitions. A source installation built only
-from the old base SQL and migrations can instead retain generated appearance placeholders.
-Importing this baseline before first startup gives new installations the repack definitions.
-Upgrading an older populated source database requires reviewed differences and, for existing
-placeholder equipment, handling saved item durability in the character database separately.
+Import the package into an empty world schema before the first worldserver startup.
+See the [world data tools](../../apps/coa-world/README.md) for installation, auditing,
+and package updates.

--- a/modules/mod-ascension-compat/README.md
+++ b/modules/mod-ascension-compat/README.md
@@ -23,13 +23,9 @@ protocol, data or process problem.
 
 ## World database installation
 
-For a new CoA source installation, import the versioned world-content baseline
-before the first worldserver startup. The repack includes harvested content that
-the stock AzerothCore base SQL and historical migrations do not fully reproduce.
-See [the world-content workflow](../../apps/coa-world/README.md) for the guarded
-empty-schema import and the read-only audit of existing installations. Keep later
-content changes in tracked pending SQL migrations so source installations and
-future repacks use the same data.
+Import the [world database package](../../apps/coa-world/README.md) into an empty
+world schema before the first worldserver startup. The same guide covers auditing
+an existing database and updating the package.
 
 ## Login and natural regeneration
 


### PR DESCRIPTION
## Problem and resulting behavior

Focus the world-data READMEs on the package contents and how to install, audit, and update it. Remove repack comparisons, past PR discussion, item examples, and historical validation reports. Simplify the related installation text in the main and module READMEs.

## Validation and remaining limits

Checked relative links, documented CLI options, and formatting. `git diff --check` passed. This changes four Markdown files only.

- [x] AI assistance: Codex (GPT-6) produced the documentation changes and this description.

## Data/source dependencies

The data archive, manifest, scripts, and applied SQL are unchanged. No credentials, profiles, or game archives are added.
