### PR TITLE
fix(Spells): fix Ascension spell modifier packet (tested on starcaller spells)

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10149,6 +10149,13 @@ void Player::AddSpellMod(SpellModifier* mod, bool apply)
     LOG_DEBUG("spells.aura", "Player::AddSpellMod {}", mod->spellId);
     uint16 Opcode = (mod->type == SPELLMOD_FLAT) ? SMSG_SET_FLAT_SPELL_MODIFIER : SMSG_SET_PCT_SPELL_MODIFIER;
 
+    bool const useAscensionSpellModifierLayout =
+        GetSession() &&
+        GetSession()->GetRemoteAddress() == "127.0.0.1" &&
+        sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false);
+    SpellInfo const* modSpell = sSpellMgr->GetSpellInfo(mod->spellId);
+    uint32 const spellFamily = modSpell ? modSpell->SpellFamilyName : 0;
+
     int i = 0;
     flag96 _mask = 0;
     for (int eff = 0; eff < 96 && mod->op < MAX_CLIENT_SPELLMOD; ++eff)
@@ -10163,22 +10170,29 @@ void Player::AddSpellMod(SpellModifier* mod, bool apply)
             for (SpellModContainer::iterator itr = m_spellMods[mod->op].begin(); itr != m_spellMods[mod->op].end(); ++itr)
             {
                 if ((*itr)->type == mod->type && (*itr)->mask & _mask)
+                {
+                    if (useAscensionSpellModifierLayout)
+                    {
+                        SpellInfo const* itrSpell = sSpellMgr->GetSpellInfo((*itr)->spellId);
+                        if (!itrSpell || itrSpell->SpellFamilyName != spellFamily)
+                            continue;
+                    }
                     val += (*itr)->value;
+                }
             }
             val += apply ? mod->value : -(mod->value);
-            bool const useAscensionSpellModifierLayout =
-                GetSession()->GetRemoteAddress() == "127.0.0.1" &&
-                sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false);
             WorldPacket data(Opcode, useAscensionSpellModifierLayout ? 11 : 6);
             if (useAscensionSpellModifierLayout)
             {
-                // The custom client keeps modifiers per character spec. Mode
-                // zero is one modifier followed by the active spec index.
+                // In Ascension's multi-class modifier engine, mode 0 (11 bytes) specifies
+                // an individual modifier where the trailing uint32 is the SpellFamilyName
+                // (e.g. 32 for Starcaller, 9 for Hunter), indexing client table slice:
+                // SpellFamilyName * 0x11A0 + eff * 31 + opType.
                 data << uint8(0);
                 data << uint8(eff);
                 data << uint8(mod->op);
                 data << int32(val);
-                data << uint32(0);
+                data << uint32(spellFamily);
             }
             else
             {

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -43,6 +43,7 @@
 #include "ObjectMgr.h"
 #include "Opcodes.h"
 #include "Pet.h"
+#include "SpellMgr.h"
 #include "Player.h"
 #include "PlayerDump.h"
 #include "QueryHolder.h"
@@ -1242,41 +1243,83 @@ void WorldSession::HandlePlayerLoginToCharInWorld(Player* pCurrChar)
             if (spellMods.empty())
                 continue;
 
-            for (int32 eff = 0; eff < 96; ++eff)
+            bool const useAscensionSpellModifierLayout =
+                GetRemoteAddress() == "127.0.0.1" &&
+                sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false);
+
+            if (useAscensionSpellModifierLayout)
             {
-                if (eff != 0 && eff % 32 == 0)
-                    _mask[i++] = 0;
-
-                _mask[i] = uint32(1) << (eff - (32 * i));
-                int32 val = 0;
+                std::unordered_set<uint32> families;
                 for (auto const& spellMod : spellMods)
-                    if (spellMod->type == modType && spellMod->mask & _mask)
-                        val += spellMod->value;
-
-                if (val == 0)
-                    continue;
-
-                bool const useAscensionSpellModifierLayout =
-                    GetRemoteAddress() == "127.0.0.1" &&
-                    sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false);
-                WorldPacket data(Opcode, useAscensionSpellModifierLayout ? 11 : 6);
-                if (useAscensionSpellModifierLayout)
                 {
-                    // Ascension prefixes individual modifier updates with a
-                    // zero mode byte and appends the character-spec index.
-                    data << uint8(0);
+                    if (spellMod->type == modType)
+                    {
+                        SpellInfo const* info = sSpellMgr->GetSpellInfo(spellMod->spellId);
+                        families.insert(info ? info->SpellFamilyName : 0);
+                    }
+                }
+
+                for (uint32 family : families)
+                {
+                    int32 fi = 0;
+                    flag96 fmask = 0;
+                    for (int32 eff = 0; eff < 96; ++eff)
+                    {
+                        if (eff != 0 && eff % 32 == 0)
+                            fmask[fi++] = 0;
+
+                        fmask[fi] = uint32(1) << (eff - (32 * fi));
+                        int32 val = 0;
+                        for (auto const& spellMod : spellMods)
+                        {
+                            if (spellMod->type == modType && (spellMod->mask & fmask))
+                            {
+                                SpellInfo const* info = sSpellMgr->GetSpellInfo(spellMod->spellId);
+                                uint32 const sFam = info ? info->SpellFamilyName : 0;
+                                if (sFam == family)
+                                    val += spellMod->value;
+                            }
+                        }
+
+                        if (val == 0)
+                            continue;
+
+                        // In Ascension's multi-class modifier engine, mode 0 (11 bytes) specifies
+                        // an individual modifier where the trailing uint32 is the SpellFamilyName
+                        // (e.g. 32 for Starcaller, 9 for Hunter), indexing client table slice:
+                        // SpellFamilyName * 0x11A0 + eff * 31 + opType.
+                        WorldPacket data(Opcode, 11);
+                        data << uint8(0);
+                        data << uint8(eff);
+                        data << uint8(opType);
+                        data << int32(val);
+                        data << uint32(family);
+                        SendPacket(&data);
+                    }
+                }
+            }
+            else
+            {
+                for (int32 eff = 0; eff < 96; ++eff)
+                {
+                    if (eff != 0 && eff % 32 == 0)
+                        _mask[i++] = 0;
+
+                    _mask[i] = uint32(1) << (eff - (32 * i));
+                    int32 val = 0;
+                    for (auto const& spellMod : spellMods)
+                        if (spellMod->type == modType && (spellMod->mask & _mask))
+                            val += spellMod->value;
+
+                    if (val == 0)
+                        continue;
+
+                    WorldPacket data(Opcode, 6);
                     data << uint8(eff);
                     data << uint8(opType);
                     data << int32(val);
-                    data << uint32(0);
+                    SendPacket(&data);
                 }
-                else
-                {
-                    data << uint8(eff);
-                    data << uint8(opType);
-                    data << int32(val);
-                }
-                SendPacket(&data);
             }
         }
     }


### PR DESCRIPTION
Hi, I noticed starcaller spells/autoshoot had 30/35 yards range instead of the 45 yards in "retail" Ascension.
Spells 805527 and 573711 were missing from starter spells but learning them didn't help with casting the spell at 30yards + or updating the tooltips clientside, while using .cast 680220 worked fine at 45 yards.
So I sent the AI digging and he managed to fix it, here are it's findings :

## Problem Description

On CoA / Ascension custom classes (such as Class 26 Starcaller), spell range passives targeting specific spell families were not updating the client tooltips or client-side action bar ranges:
- **Spell 805527** (*Starcaller Range Passive*): +15 yards to Starcaller abilities (`SpellFamilyName = 32`). *Moon Arrow* displayed at 30y instead of 45y.
- **Spell 573711** (*Starcaller Auto Shot Range*): +10 yards to Auto Shot (`SpellFamilyName = 9`). *Auto Shot* displayed at 35y instead of 45y.

Server-side combat range checks were working correctly (`SpellInfo::GetMaxRange`), but the Ascension client UI was not reflecting the modifiers.

---

## Root Cause (Binary Disassembly of Extensions.dll)

In commit `d077a19a`, Ascension's 11-byte modifier packet format was introduced in `Player.cpp` and `CharacterHandler.cpp`, but the trailing 4 bytes were assumed to be the character spec index and hardcoded to `0`:

```cpp
data << uint8(0);
data << uint8(eff);
data << uint8(mod->op);
data << int32(val);
data << uint32(0); // Assumed active spec index
```

Disassembly of Ascension's `Extensions.dll` (`0x10325B70` and `0x103288A0`) reveals that Ascension uses a multi-class modifier lookup table indexed by `SpellFamilyName`, not spec index:

$$\text{index} = \mathbf{SpellFamilyName} \times \text{0x11A0} + \text{eff} \times 31 + \text{opType}$$

- In the packet receiver at `0x10325bb2`: `imul eax, ecx, 0x11a0` multiplies the trailing `uint32` (`ecx`) by `0x11A0`.
- In `CGSpellBook::GetSpellMod` detour at `0x1032893e`: `imul edx, DWORD PTR [esi+0x240], 0x11a0` multiplies `SpellEntry->SpellFamilyName` by `0x11A0`.

Because `uint32(0)` was sent by the server, all modifiers were stored under Family 0 (Neutral). Spells belonging to Family 32 (*Moon Arrow*) or Family 9 (*Auto Shot*) checked their respective family slices and found 0 modifiers.

---

## Solution

1. **`Player::AddSpellMod`**:
   - Extract `SpellFamilyName` from `mod->spellId`.
   - In Ascension mode, aggregate `val` only across modifiers matching that `SpellFamilyName`.
   - Send `data << uint32(spellFamily);` instead of `uint32(0)`.

2. **`CharacterHandler.cpp` (`HandlePlayerLoginToCharInWorld`)**:
   - When sending initial modifiers on login, group active modifiers by `SpellFamilyName`.
   - Send an 11-byte packet per family so each family's slice in the client table is properly initialized.