### PR TITLE
fix(Core/Network): Enable remote CoA clients

### DIFF
--- a/apps/client-compat/README.md
+++ b/apps/client-compat/README.md
@@ -1,0 +1,39 @@
+# Native client world-address compatibility
+
+The native v4 client can authenticate to a remote authserver, then crash when entering
+the world. `Extensions.dll` checks the world endpoint against its own address allowlist.
+On rejection it overwrites three bytes at EXE address `0x403340`, corrupting an active hook.
+
+`patch_world_endpoint.py` reproduces the verified fix from the accepted native v4 DLL.
+It changes one conditional branch byte to skip that destructive failure block. The client
+uses the world address supplied by the authserver, with no per-IP exception. Native address
+parsing, SRP authentication and session proofs remain unchanged. The EXE is unchanged.
+
+## Generate a candidate
+
+Python 3.11 or newer is sufficient; no game files are included in this repository.
+
+```sh
+python apps/client-compat/patch_world_endpoint.py \
+  --input /path/to/native-v4/Extensions.dll \
+  --output /path/to/new-candidate/Extensions.dll
+```
+
+The output parent directory must exist. The tool refuses unknown input hashes, in-place
+changes and existing outputs. An already patched input can produce another identical
+candidate. It never installs files, opens the client or changes accounts, profiles or caches.
+
+| File | SHA256 |
+| --- | --- |
+| Accepted baseline DLL | `f7b713095aab17a1e376f487290d4b7c4c18931635e4d91136d76db2592be8fa` |
+| Patched DLL | `9791801053f828d1ccdab1a4c17e64852d3ebe0fa708b91fa3674d0805d15bc8` |
+| Unchanged companion EXE | `970cbf7e6ee5d422cec1b6a7579c70fb2b34d39b154fa8637e2a164bbdd0b201` |
+
+The DLL delta is file offset `0xA3BF4D`: `74 4A` becomes `EB 4A`. Both branches target
+DLL RVA `0xA3CB99`; the fix changes when the safe exit is taken, without adding native code.
+
+For an authorized installation, close the affected client, retain its prior DLL and update
+the native-pair manifest through the existing deployment guards. Keep the native realmlist
+and RealmData companion fixes. Set `Data/<locale>/realmlist.wtf` to the authserver and set
+the server's realm address to its reachable world endpoint. Enable the module's remote
+client compatibility settings as described in its [README](../../modules/mod-ascension-compat/README.md).

--- a/apps/client-compat/patch_world_endpoint.py
+++ b/apps/client-compat/patch_world_endpoint.py
@@ -1,0 +1,50 @@
+"""Generate the verified native world-address fix without modifying the input DLL."""
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+BASELINE_SHA256 = "f7b713095aab17a1e376f487290d4b7c4c18931635e4d91136d76db2592be8fa"
+PATCHED_SHA256 = "9791801053f828d1ccdab1a4c17e64852d3ebe0fa708b91fa3674d0805d15bc8"
+PATCH_OFFSET = 0xA3BF4D
+
+
+def generate(source, destination):
+    if source.resolve() == destination.resolve():
+        raise ValueError("Input and output must be different files; in-place patching is not supported.")
+    if destination.exists() or destination.is_symlink():
+        raise FileExistsError("Output already exists; choose a new candidate path.")
+
+    data = bytearray(source.read_bytes())
+    checksum = hashlib.sha256(data).hexdigest()
+    if checksum == BASELINE_SHA256:
+        # DLL RVA 0xA3CB4D: JE -> JMP to 0xA3CB99, preserving the displacement.
+        # The skipped failure block corrupts the active EXE hook at 0x403340.
+        if data[PATCH_OFFSET:PATCH_OFFSET + 2] != bytes.fromhex("744a"):
+            raise ValueError("The expected native world-address branch is missing.")
+        data[PATCH_OFFSET] = 0xEB
+    elif checksum != PATCHED_SHA256:
+        raise ValueError("Unsupported Extensions.dll; expected the pinned native v4 baseline or patched DLL.")
+
+    if hashlib.sha256(data).hexdigest() != PATCHED_SHA256:
+        raise ValueError("Patched DLL does not match the verified output.")
+    # Exclusive creation also protects an output created after the initial check.
+    with destination.open("xb") as output:
+        output.write(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Pinned native v4 Extensions.dll")
+    parser.add_argument("--output", required=True, type=Path, help="New candidate file; never overwritten")
+    args = parser.parse_args()
+    try:
+        generate(args.input, args.output)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    print(f"Generated {args.output}; SHA256 {PATCHED_SHA256}. No client was installed or launched.")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/coa-world/test_mysql.py
+++ b/apps/coa-world/test_mysql.py
@@ -21,13 +21,13 @@ def migrate_source(mysql):
 
 
 def apply_updates(mysql):
-    recorded = {row[0]: (row[1].lower(), row[2]) for row in mysql.query("SELECT name,hash,state FROM updates;")}
+    recorded = {row[0]: (row[1], row[2]) for row in mysql.query("SELECT name,hash,state FROM updates;")}
     released = [(p, "RELEASED") for p in sorted((ROOT / "data/sql/updates/db_world").glob("*.sql"))]
     pending = [(p, "PENDING") for p in (ROOT / "data/sql/updates/pending_db_world").glob("*.sql")]
     modules = [(p, "MODULE") for p in (ROOT / "modules/mod-ascension-compat/data/sql/db-world").glob("*.sql")]
     applied = []
     for path, state in released + sorted(pending + modules, key=lambda entry: entry[0].name):
-        checksum = native_sql_hash(path.read_bytes())
+        checksum = native_sql_hash(path.read_bytes()).upper()
         previous = recorded.get(path.name)
         # These are active directories: an ARCHIVED ledger state alone does not skip their hash check.
         if previous and previous[0] == checksum:

--- a/apps/coa-world/test_world_data.py
+++ b/apps/coa-world/test_world_data.py
@@ -130,6 +130,21 @@ class WorldDataTests(unittest.TestCase):
         self.assertEqual(database.statements[-1], "ROLLBACK;")
         self.assertNotIn("COMMIT;", database.statements)
 
+    def test_rebound_hash_uses_native_updater_casing(self):
+        class Ledger:
+            def __init__(self):
+                self.statements = []
+
+            def query(self, sql):
+                self.statements.append(sql)
+                return [["1"]] if sql.startswith("UPDATE") else []
+
+        database = Ledger()
+        reconcile_ledger(database, [("rev_test.sql", "a" * 40, "b" * 40)])
+        self.assertIn("SET `hash`='" + "B" * 40 + "'", database.statements[1])
+        self.assertIn("LOWER(`hash`)='" + "a" * 40 + "'", database.statements[1])
+        self.assertEqual(database.statements[-1], "COMMIT;")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/coa-world/world_data.py
+++ b/apps/coa-world/world_data.py
@@ -223,7 +223,8 @@ def reconcile_ledger(mysql, covered):
     mysql.query("START TRANSACTION;")
     try:
         for name, expected, native in changed:
-            rows = mysql.query("UPDATE `updates` SET `hash`='" + native + "' WHERE `name`='" + name
+            # UpdateFetcher compares hexadecimal hashes case-sensitively and writes uppercase.
+            rows = mysql.query("UPDATE `updates` SET `hash`='" + native.upper() + "' WHERE `name`='" + name
                                + "' AND LOWER(`hash`)='" + expected + "'; SELECT ROW_COUNT();")
             if rows != [["1"]]:
                 raise ValueError("Unexpected covered migration identity: " + name)

--- a/modules/mod-ascension-compat/README.md
+++ b/modules/mod-ascension-compat/README.md
@@ -54,6 +54,14 @@ accounts are disconnected after exceeding `MaxOverspeedPings`, while GM permissi
 the five-second cadence with a one-second jitter margin. Faster sustained flooding
 still reaches the strike limit. Other connections retain the stock limit.
 
+For a realm dedicated to this client, set `AscensionCompat.AllowRemoteClients = 1`
+and restart worldserver. This also applies the configured plaintext world headers,
+extension opcode range and ping interval to remote connections. The default is `0`;
+password proofs, IP bans and packet size validation remain required.
+The native v4 client also needs the [world-address fix](../../apps/client-compat/README.md)
+to enter remote worlds without its DLL corrupting an active client hook. That fix uses
+the authserver's realm address without a per-IP allowlist.
+
 The `gtOCTRegenHP`, `gtRegenHPPerSpt` and `gtRegenMPPerSpt` client files each contain
 3,200 single-float rows indexed by class and level. Their SQL tables contain explicit
 IDs, with the stock dataset covering only IDs 0–1099. The DBC loader accepts implicit

--- a/modules/mod-ascension-compat/conf/mod_ascension_compat.conf.dist
+++ b/modules/mod-ascension-compat/conf/mod_ascension_compat.conf.dist
@@ -7,8 +7,13 @@
 # Enable the compatibility packet filter.
 AscensionCompat.Enable = 1
 
+# Apply the Ascension protocol settings to remote connections as well as loopback.
+# Enable only on realms dedicated to the matching Ascension client build.
+# Authentication proofs and packet size checks remain required. Restart to apply.
+AscensionCompat.AllowRemoteClients = 0
+
 # This Ascension client keeps world packet headers plaintext after its valid
-# CMSG_AUTH_SESSION proof. Restrict the compatibility behavior to loopback.
+# CMSG_AUTH_SESSION proof. Remote use also requires AllowRemoteClients above.
 AscensionCompat.PlaintextWorldHeaders = 1
 
 # Ascension's classless character creator submits reserved WotLK class ID 10.

--- a/modules/mod-ascension-compat/tests/client_compat/harness.cpp
+++ b/modules/mod-ascension-compat/tests/client_compat/harness.cpp
@@ -147,10 +147,17 @@ World* sWorld = &world;
 struct Config
 {
     bool Enabled = false;
-    template<class T> T GetOption(char const* name, T) const
+    bool AllowRemote = false;
+    bool Plaintext = true;
+    template<class T> T GetOption(char const* name, T fallback, bool = true) const
     {
-        assert(std::strcmp(name, "AscensionCompat.Enable") == 0);
-        return T(Enabled);
+        if (std::strcmp(name, "AscensionCompat.Enable") == 0)
+            return T(Enabled);
+        if (std::strcmp(name, "AscensionCompat.AllowRemoteClients") == 0)
+            return T(AllowRemote);
+        if (std::strcmp(name, "AscensionCompat.PlaintextWorldHeaders") == 0)
+            return T(Plaintext);
+        return fallback;
     }
 } config;
 Config* sConfigMgr = &config;
@@ -207,10 +214,11 @@ bool Ping(WorldSocket& socket, std::chrono::milliseconds elapsed)
     return socket.HandlePing(packet);
 }
 
-void TestPing(bool enabled, bool loopback, bool gm, bool expected)
+void TestPing(bool enabled, bool loopback, bool gm, bool expected, bool allowRemote = false)
 {
     using namespace std::chrono_literals;
     config.Enabled = enabled;
+    config.AllowRemote = allowRemote;
     WorldSession session;
     session.GM = gm;
     WorldSocket socket(IoContextTcpSocket{loopback});
@@ -219,20 +227,24 @@ void TestPing(bool enabled, bool loopback, bool gm, bool expected)
     for (int i = 0; i < 24 && connected; ++i)
         connected = Ping(socket, 5s);
     Check(connected == expected && session.Latency == 42,
-        enabled && loopback && !gm ? "ordinary Ascension account accepts two minutes of five-second pings" :
-        gm ? "existing GM permission remains effective" : "stock and remote sessions retain the 27-second limit");
+        enabled && (loopback || allowRemote) && !gm ?
+        "ordinary Ascension account accepts two minutes of five-second pings" :
+        gm ? "existing GM permission remains effective" : "unconfigured sessions retain the 27-second limit");
+    Check(socket._usePlaintextWorldHeaders == (loopback || allowRemote),
+        "plaintext headers require loopback or explicit remote configuration");
 }
 
-void TestFlood()
+void TestFlood(bool loopback = true)
 {
     using namespace std::chrono_literals;
     config.Enabled = true;
+    config.AllowRemote = !loopback;
     WorldSession session;
-    WorldSocket socket(IoContextTcpSocket{true});
+    WorldSocket socket(IoContextTcpSocket{loopback});
     socket._worldSession = &session;
     Check(Ping(socket, 0ms) && Ping(socket, 1s) && Ping(socket, 1s) && !Ping(socket, 1s),
         "ordinary Ascension accounts are still disconnected for sustained ping flooding");
-    WorldSocket recovered(IoContextTcpSocket{true});
+    WorldSocket recovered(IoContextTcpSocket{loopback});
     recovered._worldSession = &session;
     Check(Ping(recovered, 0ms) && Ping(recovered, 1s) && Ping(recovered, 1s) && Ping(recovered, 4s) &&
         Ping(recovered, 1s), "jitter margin and good intervals reset overspeed strikes");
@@ -258,8 +270,11 @@ int main(int argc, char** argv)
     TestPing(true, true, false, true);
     TestPing(false, true, false, false);
     TestPing(true, false, false, false);
+    TestPing(true, false, false, true, true);
+    TestPing(false, false, false, false, true);
     TestPing(false, true, true, true);
     TestFlood();
+    TestFlood(false);
     std::cout << checks - failures << '/' << checks << " checks passed\n";
     return failures ? 1 : 0;
 }

--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -125,10 +125,21 @@ WorldSocket::WorldSocket(IoContextTcpSocket&& socket)
     Acore::Crypto::GetRandomBytes(_authSeed);
     _headerBuffer.Resize(sizeof(ClientPktHeader));
 
-    // Extensions.dll changes the local Ascension client's ping period to five seconds.
+    bool const allowAscensionClient = GetRemoteIpAddress().is_loopback() ||
+        sConfigMgr->GetOption<bool>("AscensionCompat.AllowRemoteClients", false, false);
+    _ascensionCompatEnabled = allowAscensionClient &&
+        sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false, false);
+    _usePlaintextWorldHeaders = allowAscensionClient &&
+        sConfigMgr->GetOption<bool>("AscensionCompat.PlaintextWorldHeaders", false, false);
+
+    // Extensions.dll changes the Ascension client's ping period to five seconds.
     // Allow one second of jitter while retaining the ordinary overspeed strike limit.
-    if (GetRemoteIpAddress().is_loopback() && sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false))
+    if (_ascensionCompatEnabled)
+    {
         _minimumPingInterval = std::chrono::seconds(4);
+        _firstAscensionExtensionOpcode = sConfigMgr->GetOption<uint32>("AscensionCompat.FirstExtensionOpcode", 0x051F);
+        _lastAscensionExtensionOpcode = sConfigMgr->GetOption<uint32>("AscensionCompat.LastExtensionOpcode", 0x09D3);
+    }
 }
 
 WorldSocket::~WorldSocket() = default;
@@ -335,12 +346,10 @@ bool WorldSocket::ReadHeaderHandler()
             rawHeader, cryptInitialized, header->size, header->cmd);
     }
 
-    bool const isLoopbackAscensionExtension = GetRemoteIpAddress().is_loopback() &&
-        sConfigMgr->GetOption<bool>("AscensionCompat.Enable", false) &&
-        header->cmd >= sConfigMgr->GetOption<uint32>("AscensionCompat.FirstExtensionOpcode", 0x051F) &&
-        header->cmd <= sConfigMgr->GetOption<uint32>("AscensionCompat.LastExtensionOpcode", 0x09D3);
+    bool const isAscensionExtension = _ascensionCompatEnabled &&
+        header->cmd >= _firstAscensionExtensionOpcode && header->cmd <= _lastAscensionExtensionOpcode;
 
-    if (!header->IsValidSize() || (!header->IsValidOpcode() && !isLoopbackAscensionExtension))
+    if (!header->IsValidSize() || (!header->IsValidOpcode() && !isAscensionExtension))
     {
         LOG_ERROR("network",
             "WorldSocket::ReadHeaderHandler(): client {} sent malformed packet "
@@ -624,8 +633,7 @@ void WorldSocket::HandleAuthSessionCallback(std::shared_ptr<ClientAuthSession> a
 
     AccountInfo account(result->Fetch());
 
-    bool const usePlaintextWorldHeaders = GetRemoteIpAddress().is_loopback() &&
-        sConfigMgr->GetOption<bool>("AscensionCompat.PlaintextWorldHeaders", false);
+    bool const usePlaintextWorldHeaders = _usePlaintextWorldHeaders;
 
     // For hook purposes, we get Remoteaddress at this point.
     std::string address = sConfigMgr->GetOption<bool>("AllowLoggingIPAddressesInDatabase", true, true) ? GetRemoteIpAddress().to_string() : "0.0.0.0";

--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -125,6 +125,10 @@ private:
     TimePoint _LastPingTime;
     uint32 _OverSpeedPings;
     std::chrono::seconds _minimumPingInterval{27};
+    bool _ascensionCompatEnabled = false;
+    bool _usePlaintextWorldHeaders = false;
+    uint32 _firstAscensionExtensionOpcode = 0;
+    uint32 _lastAscensionExtensionOpcode = 0;
 
     std::mutex _worldSessionLock;
     WorldSession* _worldSession;


### PR DESCRIPTION
## Problem and resulting behavior

Remote CoA clients could authenticate but fail to stay connected or crash on world entry.

- Add opt-in `AscensionCompat.AllowRemoteClients` so dedicated realms apply the matching plaintext world headers, extension opcode range and five-second ping compatibility to remote connections. Cache these settings per connection while retaining authentication, packet-size checks and flood limits.
- Add a hash-pinned, candidate-only client DLL patcher that skips the destructive world-address allowlist rejection. The client accepts the authserver's realm address without per-IP exceptions. The EXE is unchanged; the DLL change is one branch byte. Unknown inputs, in-place changes and existing outputs are rejected.
- Write reconciled world-bootstrap migration hashes in the uppercase format used by the native updater, preventing already-covered migrations from replaying because of hash casing. Update the regression checks to compare hashes exactly.

## Validation and remaining limits

- 30 native DBC/socket compatibility checks passed, including ordinary remote accounts, default behavior and ping-flood enforcement.
- 10 world-data unit tests, scoped C++ codestyle checks and Git whitespace checks passed.
- 8 candidate-generation and preservation checks passed; the repository patcher reproduces the exact client DLL used for acceptance.
- 355 native client checks passed for authentication, world addresses, realmlist/DNS/ports and preserved lighting behavior.
- A Linux Release build completed successfully. Live remote testing passed SRP/server proof, realm listing, world-session proof, character enumeration and 26 ping replies over 127 seconds. Invalid world proofs, malformed packet sizes and out-of-range opcodes were rejected.
- The user confirmed character creation and normal world entry with the final general-address client; movement and an active world connection were observed.

The native checks use explicit fixtures for operating-system/GPU boundaries; they do not establish full gameplay parity. The client patcher supports only the documented native v4 file pair. The full disposable-MySQL comparison suite was not rerun; database validation used the unit tests and live bootstrap/updater behavior.

## Data/source dependencies

Applied SQL files are unchanged. No server-specific configuration, addresses, credentials, account/profile data, deployment records or game binaries/archives are included. Client input files must be supplied locally; only the reproducible patch source and documentation are tracked.

AI assistance: Codex (GPT-6) prepared the changes and PR description; the user performed the in-game acceptance test.